### PR TITLE
Ci changes for mac os

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,6 @@ jobs:
     - name: Install MacOS brew
       if: runner.os == 'macOS'
       run: |
-        brew update
         brew install pkg-config ffmpeg@4 libarchive libvorbis flac
 
     - name: SFML - Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Install MacOS brew
       if: runner.os == 'macOS'
       run: |
-        brew install pkg-config ffmpeg@4 libarchive libvorbis flac
+        brew install pkg-config ffmpeg libarchive libvorbis flac
 
     - name: SFML - Checkout
       uses: actions/checkout@v3
@@ -93,7 +93,7 @@ jobs:
     - name: AM+ - Build
       run: ${{matrix.platform.ammakeopts}} make -C am -j$(nproc) ${{matrix.platform.amosflags}} ${{matrix.config.amflags}} ${{env.cross_toolchain}} VERBOSE=1
       env:
-        PKG_CONFIG_PATH: "${{github.workspace}}/sfml/install:${{github.workspace}}/sfml/install/pkgconfig:/usr/local/opt/ffmpeg@4/lib/pkgconfig"
+        PKG_CONFIG_PATH: "${{github.workspace}}/sfml/install:${{github.workspace}}/sfml/install/pkgconfig"
         PKG_CONFIG_PATH_x86_64_w64_mingw32_${{matrix.config.name}}: "${{github.workspace}}/sfml/install/pkgconfig"
         EXTRA_CFLAGS: "${{matrix.platform.amextracflags}}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         platform:
         - { name: Windows MXE, os: ubuntu-20.04, crossprefix: x86_64-w64-mingw32.static-, amosflags: CROSS=1 FE_WINDOWS_COMPILE=1 }
         - { name: Linux GCC,   os: ubuntu-20.04, flags: -DSFML_USE_DRM=1,                 amosflags: USE_DRM=1 }
-        - { name: MacOS XCode, os: macos-10.15,  flags: -DSFML_USE_SYSTEM_DEPS=1 }
+        - { name: MacOS XCode, os: macos-11,  flags: -DSFML_USE_SYSTEM_DEPS=1 }
         config:
         - { name: shared, flags: -DBUILD_SHARED_LIBS=TRUE }
         - { name: static, flags: -DBUILD_SHARED_LIBS=FALSE, amflags: STATIC=1 }
@@ -27,7 +27,7 @@ jobs:
         exclude:
         - platform: { os: ubuntu-20.04 }
           config: { name: shared }
-        - platform: { os: macos-10.15 }
+        - platform: { os: macos-11 }
           config: { name: static }
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ else
 endif
 
 ifeq ($(FE_MACOSX_COMPILE),1)
-  LIBS += -framework OpenGL -ljpeg
+  LIBS += -framework OpenGL -L/opt/homebrew/Cellar/jpeg/9e/lib -ljpeg
 endif
 
 ifneq ($(FE_WINDOWS_COMPILE),1)


### PR DESCRIPTION
- remove ffmpeg@4 and build directly with ffmpeg5
- change runner from deprecated macos-10.15 to macos-11 (still works on Catalina)
- remove brew update which is not needed and breaks the build process due to Python
- added a line in makefile to fix building on Apple Silicon and linking ljpeg