### PR TITLE
"Yes/No" translation conflict in "Generate Collection/Rom List"

### DIFF
--- a/src/fe_config.cpp
+++ b/src/fe_config.cpp
@@ -632,7 +632,7 @@ void FeEmulatorGenMenu::get_options( FeConfigContext &ctx )
 			itr < emu_file_list.end(); ++itr )
 	{
 		ctx.add_opt( Opt::LIST, *itr,
-			defaults.contains( *itr ) ? "Yes" : "No",
+			defaults.contains( *itr ) ? bool_opts[0] : bool_opts[1],
 			"_help_generator_opt" );
 
 		ctx.back_opt().append_vlist( bool_opts );


### PR DESCRIPTION
If the user is using a translation, the "Yes/No" texts will persist and a conflict will occur when confirming the function.

Spanish
![image](https://github.com/oomek/attractplus/assets/2616950/ea65d07f-92d9-4fd0-8832-b840bb64eed0)
![image](https://github.com/oomek/attractplus/assets/2616950/806f4619-b1b2-4834-9684-98891664047e)

