### PR TITLE
Fix splash message aux text

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -1486,10 +1486,12 @@ Member Functions:
    * `edit_dialog( msg, text )` - Prompt the user to input/edit text.  The
      `msg` parameter is the prompt caption.  `text` is the initial text to be
      edited.  The return value a the string of text as edited by the user.
-   * `splash_message( msg, rep="", aux="" )` - immediately provide text feedback
-     to the user.  This could be useful during computationally-intensive
-     operations.  The `msg` parameter may contain a `$1` placeholder that gets replaced
-     by `rep`.  The `aux` text is displayed in the footer.
+   * `splash_message( msg, replace, footer_msg )`
+	* `splash_message( msg, replace )`
+	* `splash_message( msg )` - immediately provide text feedback to the user.
+     This could be useful during computationally-intensive operations.
+     The `msg` parameter may contain a `$1` placeholder that gets replaced by `replace`.
+     The `footer_msg` text is displayed in the footer.
 
 &nbsp;
 <a name="Display"></a>

--- a/Layouts.md
+++ b/Layouts.md
@@ -1486,9 +1486,10 @@ Member Functions:
    * `edit_dialog( msg, text )` - Prompt the user to input/edit text.  The
      `msg` parameter is the prompt caption.  `text` is the initial text to be
      edited.  The return value a the string of text as edited by the user.
-   * `splash_message( msg, second_msg="" )` - immediately provide text feedback
+   * `splash_message( msg, rep="", aux="" )` - immediately provide text feedback
      to the user.  This could be useful during computationally-intensive
-     operations.
+     operations.  The `msg` parameter may contain a `$1` placeholder that gets replaced
+     by `rep`.  The `aux` text is displayed in the footer.
 
 &nbsp;
 <a name="Display"></a>

--- a/Layouts.md
+++ b/Layouts.md
@@ -1487,8 +1487,8 @@ Member Functions:
      `msg` parameter is the prompt caption.  `text` is the initial text to be
      edited.  The return value a the string of text as edited by the user.
    * `splash_message( msg, replace, footer_msg )`
-	* `splash_message( msg, replace )`
-	* `splash_message( msg )` - immediately provide text feedback to the user.
+   * `splash_message( msg, replace )`
+   * `splash_message( msg )` - immediately provide text feedback to the user.
      This could be useful during computationally-intensive operations.
      The `msg` parameter may contain a `$1` placeholder that gets replaced by `replace`.
      The `footer_msg` text is displayed in the footer.

--- a/Layouts.md
+++ b/Layouts.md
@@ -786,7 +786,7 @@ Parameters:
      containing the selection to retrieve the filename for.  i.e.
      -1=previous filter, 0=current filter.  Default value is 0.
    * flags - flags to control the filename that gets returned.  Can be set
-     to any combination of none or more of the following (i.e. `Art.ImageOnly
+     to any combination of none or more of the following (i.e. `Art.ImagesOnly
      | Art.FullList`):
       - `Art.Default` - return single match, video or image
       - `Art.ImagesOnly` - Override Art.Default, only return an image match (no
@@ -1353,7 +1353,7 @@ Properties:
    * `height` - Get/set the layout height.  Default value is `ScreenHeight`.
    * `font` - Get/set the filename of the font which will be used for
      text and listbox objects in this layout.
-   * `base_rotation` - Get the base orientation of Attract Mode wchich is set
+   * `base_rotation` - Get the base orientation of Attract Mode which is set
      in General Settings. This property cannot be set from the script.
      This can be one of the following values:
       - `RotateScreen.None` (default)
@@ -1361,7 +1361,7 @@ Properties:
       - `RotateScreen.Flip`
       - `RotateScreen.Left`
    * `toggle_rotation` - Get/set the "toggle" orientation of the layout.
-     The toggle rotation is added to the rotation sen in general settings
+     The toggle rotation is added to the rotation set in general settings
      to determine what the actual rotation is at any given time.
      The user can change this value using the Rotation Toggle inputs.
      This can be one of the following values:
@@ -1581,6 +1581,8 @@ Member Functions:
      (see [`fe.add_listbox()`](#add_listbox) for parameters and return value).
    * `add_surface()` - add a surface to the end of this monitor's draw list
      (see [`fe.add_surface()`](#add_surface) for parameters and return value).
+   * `add_rectangle()` - add a rectangle to the end of this monitor's draw list
+     (see [`fe.add_rectangle()`](#add_rectangle) for parameters and return value).
 
 Notes:
 
@@ -1776,6 +1778,9 @@ Member Functions:
    * `add_surface()` - [surface only] add a surface to the end of this
      surface's draw list (see [`fe.add_surface()`](#add_surface) for parameters
      and return value).
+   * `add_rectangle()` - [surface only] add a rectangle to the end of this
+	  surface's draw list (see [`fe.add_rectangle()`](#add_rectangle) for parameters
+	  and return value).
 
 &nbsp;
 <a name="ImageNotes"></a>

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -890,6 +890,7 @@ bool FeVM::on_new_layout()
 		.Overload<int (FeVM::*)(Array, const char *)>(_SC("list_dialog"), &FeVM::list_dialog)
 		.Overload<int (FeVM::*)(Array)>(_SC("list_dialog"), &FeVM::list_dialog)
 		.Func( _SC("edit_dialog"), &FeVM::edit_dialog )
+		.Overload<bool (FeVM::*)(const char *, const char *, const char *)>( _SC("splash_message"), &FeVM::splash_message )
 		.Overload<bool (FeVM::*)(const char *, const char *)>( _SC("splash_message"), &FeVM::splash_message )
 		.Overload<bool (FeVM::*)(const char *)>( _SC("splash_message"), &FeVM::splash_message )
 	);
@@ -1480,15 +1481,20 @@ void FeVM::overlay_clear_custom_controls()
 	m_custom_overlay = false;
 }
 
-bool FeVM::splash_message( const char *msg, const char *aux )
+bool FeVM::splash_message( const char *msg, const char *rep, const char *aux )
 {
-	m_overlay->splash_message( msg, "", aux );
+	m_overlay->splash_message( msg, rep, aux );
 	return m_overlay->check_for_cancel();
+}
+
+bool FeVM::splash_message( const char *msg, const char *rep )
+{
+	return splash_message( msg, rep, "" );
 }
 
 bool FeVM::splash_message( const char *msg )
 {
-	return splash_message( msg, "" );
+	return splash_message( msg, "", "" );
 }
 
 //
@@ -1637,6 +1643,7 @@ public:
 			//
 			fe.Bind( _SC("Overlay"), Sqrat::Class <FeVM, Sqrat::NoConstructor>()
 				.Prop( _SC("is_up"), &FeVM::overlay_is_on )
+				.Overload<bool (FeVM::*)(const char *, const char *, const char *)>( _SC("splash_message"), &FeVM::splash_message )
 				.Overload<bool (FeVM::*)(const char *, const char *)>( _SC("splash_message"), &FeVM::splash_message )
 				.Overload<bool (FeVM::*)(const char *)>( _SC("splash_message"), &FeVM::splash_message )
 			);

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1482,7 +1482,7 @@ void FeVM::overlay_clear_custom_controls()
 
 bool FeVM::splash_message( const char *msg, const char *aux )
 {
-	m_overlay->splash_message( msg, aux );
+	m_overlay->splash_message( msg, "", aux );
 	return m_overlay->check_for_cancel();
 }
 

--- a/src/fe_vm.hpp
+++ b/src/fe_vm.hpp
@@ -154,6 +154,7 @@ public:
 	void overlay_set_custom_controls( FeText *caption );
 	void overlay_set_custom_controls();
 	void overlay_clear_custom_controls();
+	bool splash_message( const char *, const char *, const char * );
 	bool splash_message( const char *, const char * );
 	bool splash_message( const char * );
 


### PR DESCRIPTION
- Added `rep` arg to FeVM::splash_message, now splash_message `second_msg` works
- Added `add_rectangle` method descriptions to `Image` and `Monitor`
- Fixed `Layout.md` typos