### PR TITLE
Fix romlist reload on display edit

### DIFF
--- a/src/fe_cache.hpp
+++ b/src/fe_cache.hpp
@@ -11,6 +11,9 @@ class FeCache
 private:
 
 	static std::string m_config_path;
+	static std::string m_romlist_args;
+
+	static void invalidate_romlist_args();
 
 public:
 
@@ -57,20 +60,20 @@ public:
 
 	// ----------------------------------------------------------------------------------
 
-	static void clear_display_cache(
+	static void invalidate_display(
 		FeDisplayInfo &display
 	);
 
-	static void clear_romlist_cache(
+	static void invalidate_romlist(
 		FeDisplayInfo &display
 	);
 
-	static void clear_filter_cache(
+	static void invalidate_filter(
 		FeDisplayInfo &display,
 		int filter_index
 	);
 
-	static void invalidate(
+	static void invalidate_rominfo(
 		FeDisplayInfo &display,
 		FeRomInfo::Index target
 	);
@@ -100,6 +103,16 @@ public:
 		FeFilterEntry &entry,
 		int filter_index,
 		std::vector<FeRomInfo*> &lookup
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	static bool set_romlist_args(
+		const std::string &path,
+		const std::string &romlist_name,
+		FeDisplayInfo &display,
+		bool group_clones,
+		bool load_stats
 	);
 
 };

--- a/src/fe_config.cpp
+++ b/src/fe_config.cpp
@@ -1252,7 +1252,7 @@ bool FeDisplayEditMenu::save( FeConfigContext &ctx )
 	if ( display )
 	{
 		// Clear this displays cache when its settings have changed
-		FeCache::clear_display_cache( *display );
+		FeCache::invalidate_display( *display );
 
 		for ( int i=0; i< FeDisplayInfo::LAST_INDEX; i++ )
 		{

--- a/src/fe_romlist.cpp
+++ b/src/fe_romlist.cpp
@@ -199,6 +199,10 @@ bool FeRomList::load_romlist( const std::string &path,
 	bool group_clones,
 	bool load_stats	)
 {
+	// Exit early if arguments have not changed - occurs during layout option edit
+	if (!FeCache::set_romlist_args(path, romlist_name, display, group_clones, load_stats))
+		return true;
+
 	sf::Clock load_timer;
 	std::string romlist_path = path + romlist_name + FE_ROMLIST_FILE_EXTENSION;
 	time_t mtime = modified_time( romlist_path );
@@ -226,7 +230,7 @@ bool FeRomList::load_romlist( const std::string &path,
 		}
 
 		// Otherwise clear cache for this display and rebuild
-		FeCache::clear_display_cache( display );
+		FeCache::invalidate_display( display );
 	}
 
 	// These properties get loaded from cache
@@ -731,7 +735,7 @@ bool FeRomList::set_fav( FeRomInfo &r, FeDisplayInfo &display, bool fav )
 	r.set_info( FeRomInfo::Favourite, fav ? "1" : "" );
 	m_fav_changed=true;
 
-	FeCache::invalidate( display, FeRomInfo::Favourite );
+	FeCache::invalidate_rominfo( display, FeRomInfo::Favourite );
 	return fix_filters( display, FeRomInfo::Favourite );
 }
 
@@ -809,7 +813,7 @@ bool FeRomList::set_tag( FeRomInfo &rom, FeDisplayInfo &display, const std::stri
 			itt = m_tags.insert( itt, std::pair<std::string,bool>( tag, true ) );
 	}
 
-	FeCache::invalidate( display, FeRomInfo::Tags );
+	FeCache::invalidate_rominfo( display, FeRomInfo::Tags );
 	return fix_filters( display, FeRomInfo::Tags );
 }
 

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -698,29 +698,17 @@ void FeSettings::init_display()
 			list_path = temp;
 	}
 
-	// Load the romlist only if the arguments have changed, otherwise use the existing one
 	if (
-		m_loaded_romlist_name != romlist_name
-		|| m_loaded_current_display != m_current_display
-		|| m_loaded_group_clones != m_group_clones
-		|| m_loaded_track_usage != m_track_usage
-	)
-	{
-		if (
-			m_rl.load_romlist( list_path,
+		m_rl.load_romlist(
+			list_path,
 			romlist_name,
 			m_displays[m_current_display],
 			m_group_clones,
-			m_track_usage ) == false
-		)
-		{
-			FeLog() << "Error opening romlist: " << romlist_name << std::endl;
-		}
-
-		m_loaded_romlist_name = romlist_name;
-		m_loaded_current_display = m_current_display;
-		m_loaded_group_clones = m_group_clones;
-		m_loaded_track_usage = m_track_usage;
+			m_track_usage
+		) == false
+	)
+	{
+		FeLog() << "Error opening romlist: " << romlist_name << std::endl;
 	}
 
 	// Setup m_current_layout_params with all the parameters for our current layout, including
@@ -2426,8 +2414,8 @@ bool FeSettings::update_stats( int play_count, int play_time )
 	{
 		if ( m_displays[i].get_romlist_name() == romlist_name )
 		{
-			FeCache::invalidate( m_displays[i], FeRomInfo::PlayedCount );
-			FeCache::invalidate( m_displays[i], FeRomInfo::PlayedTime );
+			FeCache::invalidate_rominfo( m_displays[i], FeRomInfo::PlayedCount );
+			FeCache::invalidate_rominfo( m_displays[i], FeRomInfo::PlayedTime );
 		}
 	}
 

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -259,17 +259,14 @@ private:
 	int m_ui_font_size;
 	std::string m_ui_color;
 
-	std::string m_loaded_romlist_name;
-	int m_loaded_current_display;
-	bool m_loaded_group_clones;
-	bool m_loaded_track_usage;
-
 	FeSettings( const FeSettings & );
 	FeSettings &operator=( const FeSettings & );
 
 	int process_setting( const std::string &,
 		const std::string &,
 		const std::string & );
+
+	void validate_romlist();
 
 	void init_display();
 	void load_state();


### PR DESCRIPTION
- The "Layout Preview" branch introduced conditional running of "load_romlist" (ie: check if args changed)
- This improved the reload speed between layout option changes
- However, other events such as Display-edit also require a reload (but don't change the args)
- Condition has now been moved to FeCache, and is invalidated on same events that cause cache invalidation

How to test:
- Configure Layout with "Layout Preview" on will NOT trigger a romlist reload
- Editing a Display filter WILL trigger a romlist reload (on menu exit)