### PR TITLE
Improve dynamic data caching

### DIFF
--- a/src/fe_cache.cpp
+++ b/src/fe_cache.cpp
@@ -15,28 +15,64 @@ const char *FE_CACHE_EXT = ".json";
 #endif // FE_CACHE_BINARY
 
 const char *FE_CACHE_SUBDIR = "cache/";
-const char *FE_CACHE_ROMLIST = ".romlist";
-const char *FE_CACHE_FILTER = ".filter";
+const char *FE_CACHE_STATS = "stats";
+const char *FE_CACHE_FILTER = "filter";
+const char *FE_CACHE_DISPLAY = "display";
+const char *FE_CACHE_ROMLIST = "romlist";
+const char *FE_CACHE_GLOBALFILTER = "globalfilter";
 const std::string FE_EMPTY_STRING;
 
-std::string FeCache::m_config_path;
-std::string FeCache::m_romlist_args;
+std::vector<FeDisplayInfo>* FeCache::m_displays = {};
+std::string FeCache::m_config_path = "";
+std::string FeCache::m_romlist_args = "";
+
+// Global storage for [emulator][romname] stats
+std::map<std::string, FeListStats> FeCache::stats_cache = std::map<std::string, FeListStats>{};
 
 // -------------------------------------------------------------------------------------
 
 //
 // Create path for config files
 //
-void FeCache::set_config_path( std::string path )
+void FeCache::set_config_path(
+	std::string path
+)
 {
 	m_config_path = path;
 	confirm_directory( m_config_path, FE_CACHE_SUBDIR );
 }
 
 //
+// Store the displays lists, since cache sometimes need to invalidate multiple of them
+//
+void FeCache::set_displays(
+	std::vector<FeDisplayInfo>* displays
+)
+{
+	m_displays = displays;
+};
+
+// -------------------------------------------------------------------------------------
+
+//
 // Returns sanitized filename for romlist cache
 //
 std::string FeCache::get_romlist_cache_filename(
+	const std::string &romlist_name
+)
+{
+	if ( romlist_name.empty() ) return FE_EMPTY_STRING;
+	return m_config_path
+		+ FE_CACHE_SUBDIR
+		+ FE_CACHE_ROMLIST + "."
+		+ sanitize_filename( romlist_name )
+		+ FE_CACHE_EXT;
+}
+
+//
+// Returns sanitized filename for globalfilter cache
+//
+std::string FeCache::get_globalfilter_cache_filename(
 	FeDisplayInfo &display
 )
 {
@@ -44,8 +80,9 @@ std::string FeCache::get_romlist_cache_filename(
 	if ( name.empty() ) return FE_EMPTY_STRING;
 	return m_config_path
 		+ FE_CACHE_SUBDIR
-		+ sanitize_filename( name )
-		+ FE_CACHE_ROMLIST
+		+ FE_CACHE_DISPLAY + "."
+		+ sanitize_filename( name ) + "."
+		+ FE_CACHE_GLOBALFILTER
 		+ FE_CACHE_EXT;
 }
 
@@ -61,143 +98,71 @@ std::string FeCache::get_filter_cache_filename(
 	if ( name.empty() ) return FE_EMPTY_STRING;
 	return m_config_path
 		+ FE_CACHE_SUBDIR
-		+ sanitize_filename( name )
-		+ FE_CACHE_FILTER
-		+ "." + as_str(filter_index)
+		+ FE_CACHE_DISPLAY + "."
+		+ sanitize_filename( name ) + "."
+		+ FE_CACHE_FILTER + "."
+		+ as_str( filter_index )
+		+ FE_CACHE_EXT;
+}
+
+//
+// Returns sanitized filename for stat cache
+//
+std::string FeCache::get_stats_cache_filename(
+	std::string &emulator
+)
+{
+	if ( emulator.empty() ) return FE_EMPTY_STRING;
+	return m_config_path
+		+ FE_CACHE_SUBDIR
+		+ FE_CACHE_STATS + "."
+		+ sanitize_filename( emulator )
 		+ FE_CACHE_EXT;
 }
 
 // -------------------------------------------------------------------------------------
 
 //
-// Converts FeRomInfo pointers to indexes for caching
+// Clears all cache using the given romlist (displays > globalfilters and filters)
 //
-void FeCache::filter_list_to_indexes(
-	std::vector<int> &indexes,
-	std::vector<FeRomInfo*> &list
+void FeCache::invalidate_romlist(
+	const std::string &romlist_name
 )
 {
-	indexes.clear();
-	indexes.reserve( list.size() );
-
-	std::transform(
-		list.begin(),
-		list.end(),
-		std::back_inserter( indexes ),
-		[]( FeRomInfo* info ) { return info->index; }
-	);
-}
-
-//
-// Converts mapped FeRomInfo pointers to indexes for caching
-//
-void FeCache::clone_group_to_indexes(
-	std::map<std::string, std::vector<int>> &indexes,
-	std::map<std::string, std::vector<FeRomInfo*>> &map
-)
-{
-	indexes.clear();
-
-	std::for_each(
-		map.begin(),
-		map.end(),
-		[ &indexes ]( std::pair<std::string, std::vector<FeRomInfo*>> it )
-		{
-			indexes[ it.first ] = std::vector<int>();
-			filter_list_to_indexes( indexes[ it.first ], it.second );
-		}
-	);
-}
-
-//
-// Restores indexes back to FeRomInfo pointers and inserts into list
-//
-void FeCache::indexes_to_filter_list(
-	std::vector<FeRomInfo*> &list,
-	std::vector<int> &indexes,
-	std::vector<FeRomInfo*> &lookup
-)
-{
-	list.clear();
-	list.reserve( indexes.size() );
-
-	std::transform(
-		indexes.begin(),
-		indexes.end(),
-		std::back_inserter( list ),
-		[ &lookup ]( int index ) { return lookup[index]; }
-	);
-}
-
-//
-// Restores mapped indexes back to FeRomInfo pointers and inserts into map
-//
-void FeCache::indexes_to_clone_group(
-	std::map<std::string, std::vector<FeRomInfo*>> &map,
-	std::map<std::string, std::vector<int>> &indexes,
-	std::vector<FeRomInfo*> &lookup
-)
-{
-	map.clear();
-
-	std::for_each(
-		indexes.begin(),
-		indexes.end(),
-		[ &map, &lookup ]( std::pair<std::string, std::vector<int>> it )
-		{
-			map[ it.first ] = std::vector<FeRomInfo*>();
-			indexes_to_filter_list( map[ it.first ], it.second, lookup );
-		}
-	);
-}
-
-//
-// Returns romlist romInfoList as an indexed vector of pointers
-// - Must only be used after romlist filtered, sorted and group_cloned ordered
-//
-std::vector<FeRomInfo*> FeCache::get_romlist_lookup(
-	FeRomInfoListType &m_list
-)
-{
-	std::vector<FeRomInfo*> v;
-	v.reserve(m_list.size());
-	for ( FeRomInfoListType::iterator it=m_list.begin(); it!=m_list.end(); ++it )
+	for (std::vector<FeDisplayInfo>::const_iterator itr=(*m_displays).begin(); itr!=(*m_displays).end(); ++itr)
 	{
-		v.push_back(&(*it));
+		FeDisplayInfo display = (*itr);
+		if ( display.get_romlist_name() == romlist_name ) invalidate_display( display );
 	}
-	return v;
 }
 
-// -------------------------------------------------------------------------------------
-
 //
-// Clears all cache belonging to the given display (romlist and all filters)
+// Clears all cache belonging to the given display (globalfilter and filters)
 //
 void FeCache::invalidate_display(
 	FeDisplayInfo &display
 )
 {
-	invalidate_romlist( display );
-
+	invalidate_globalfilter( display );
 	int filters_count = display.get_filter_count();
 	if ( filters_count == 0 ) filters_count = 1;
 	for ( int i=0; i<filters_count; i++ ) invalidate_filter( display, i );
 }
 
 //
-// Clears cached romlist file
+// Clears a cached globalfilter file
 //
-void FeCache::invalidate_romlist(
+void FeCache::invalidate_globalfilter(
 	FeDisplayInfo &display
 )
 {
 	invalidate_romlist_args();
-	std::string filename = get_romlist_cache_filename( display );
+	std::string filename = get_globalfilter_cache_filename( display );
 	if ( file_exists( filename ) ) delete_file( filename );
 }
 
 //
-// Clears cached filter file
+// Clears a cached filter file
 //
 void FeCache::invalidate_filter(
 	FeDisplayInfo &display,
@@ -210,32 +175,37 @@ void FeCache::invalidate_filter(
 }
 
 //
-// Clears cache for all lists that use the given RomInfo target
+// Clears cache for all displays using the given romlist, and a rule with a changed rominfo value
 // - Favourite, Tags, PlayedCount, PlayedTime
 //
 void FeCache::invalidate_rominfo(
-	FeDisplayInfo &display,
+	const std::string &romlist_name,
 	FeRomInfo::Index target
 )
 {
-	// Check whether the global filter uses the given RomInfo
-	FeFilter *global_filter = display.get_global_filter();
-	bool romlist_changed = global_filter && global_filter->test_for_target( target );
-
-	// Always clear the romlist, since it stores tags & stats that need updating
-	invalidate_romlist( display );
-
-	int filters_count = display.get_filter_count();
-
-	// if no filters there's still a single cache file containing entire romlist
-	if ( filters_count == 0 && romlist_changed ) invalidate_filter( display, 0 );
-
-	for ( int i=0; i<filters_count; i++ )
+	for (std::vector<FeDisplayInfo>::const_iterator itr=(*m_displays).begin(); itr!=(*m_displays).end(); ++itr)
 	{
-		// If the romlist has changed, or the filter uses the given RomInfo, then clear it
-		if ( romlist_changed || display.get_filter( i )->test_for_target( target ) )
+		FeDisplayInfo display = (*itr);
+		if ( display.get_romlist_name() == romlist_name )
 		{
-			invalidate_filter( display, i );
+			// Clear the globalfilter if it uses the target
+			FeFilter *global_filter = display.get_global_filter();
+			bool changed = global_filter && global_filter->test_for_target( target );
+			if ( changed ) invalidate_globalfilter( display );
+
+			int filters_count = display.get_filter_count();
+
+			// If no filters there's still a single cache file containing entire romlist
+			if ( changed && filters_count == 0 ) invalidate_filter( display, 0 );
+
+			// Clear filters that are using the target, or if the romlist has changed
+			for ( int i=0; i<filters_count; i++ )
+			{
+				if ( changed || display.get_filter( i )->test_for_target( target ) )
+				{
+					invalidate_filter( display, i );
+				}
+			}
 		}
 	}
 }
@@ -246,11 +216,11 @@ void FeCache::invalidate_rominfo(
 // Saves romlist to cache file
 //
 bool FeCache::save_romlist_cache(
-	FeDisplayInfo &display,
+	const std::string &romlist_name,
 	FeRomList &romlist
 )
 {
-	std::string filename = get_romlist_cache_filename( display );
+	std::string filename = get_romlist_cache_filename( romlist_name );
 	if ( filename.empty() ) return false;
 	nowide::ofstream file( filename, std::ios::binary );
 	if ( !file.is_open() ) return false;
@@ -267,20 +237,20 @@ bool FeCache::save_romlist_cache(
 	catch (...)
 	{
 		file.close();
-		invalidate_romlist( display );
+		invalidate_romlist( romlist_name );
 		return false;
 	}
 }
 
 //
-// Loads cache file and updates romlist
+// Loads romlist file and updates romlist
 //
 bool FeCache::load_romlist_cache(
-	FeDisplayInfo &display,
+	const std::string &romlist_name,
 	FeRomList &romlist
 )
 {
-	std::string filename = get_romlist_cache_filename( display );
+	std::string filename = get_romlist_cache_filename( romlist_name );
 	if ( !file_exists( filename ) ) return false;
 	nowide::ifstream file( filename, std::ios::binary );
 	if ( !file.is_open() ) return false;
@@ -297,7 +267,69 @@ bool FeCache::load_romlist_cache(
 	catch ( ... )
 	{
 		file.close();
-		invalidate_romlist( display );
+		invalidate_romlist( romlist_name );
+		return false;
+	}
+}
+
+// -------------------------------------------------------------------------------------
+
+//
+// Saves globalfilter to cache file
+//
+bool FeCache::save_globalfilter_cache(
+	FeDisplayInfo &display,
+	FeRomList &romlist
+)
+{
+	std::string filename = get_globalfilter_cache_filename( display );
+	if ( filename.empty() ) return false;
+	nowide::ofstream file( filename, std::ios::binary );
+	if ( !file.is_open() ) return false;
+
+	try
+	{
+		{	// block flushes archive
+			OutputArchive archive( file );
+			archive( romlist );
+		}
+		file.close();
+		return true;
+	}
+	catch (...)
+	{
+		file.close();
+		invalidate_globalfilter( display );
+		return false;
+	}
+}
+
+//
+// Loads globalfilter file and updates romlist
+//
+bool FeCache::load_globalfilter_cache(
+	FeDisplayInfo &display,
+	FeRomList &romlist
+)
+{
+	std::string filename = get_globalfilter_cache_filename( display );
+	if ( !file_exists( filename ) ) return false;
+	nowide::ifstream file( filename, std::ios::binary );
+	if ( !file.is_open() ) return false;
+
+	try
+	{
+		{	// block flushes archive
+			InputArchive archive( file );
+			archive( romlist );
+		}
+		file.close();
+		return true;
+	}
+	catch ( ... )
+	{
+		file.close();
+		invalidate_globalfilter( display );
 		return false;
 	}
 }
@@ -320,12 +352,12 @@ bool FeCache::save_filter_cache(
 
 	try
 	{
-		// Update entry indexes, which is what will be cached
-		entry.to_indexes();
-
+		// Create indexes, which is what gets cached
+		FeFilterIndexes indexes;
+		indexes.entry_to_index( entry );
 		{	// block flushes archive
 			OutputArchive archive( file );
-			archive( entry );
+			archive( indexes );
 		}
 		file.close();
 		return true;
@@ -345,7 +377,7 @@ bool FeCache::load_filter_cache(
 	FeDisplayInfo &display,
 	FeFilterEntry &entry,
 	int filter_index,
-	std::vector<FeRomInfo*> &lookup
+	std::map<int, FeRomInfo*> &lookup
 )
 {
 	std::string filename = get_filter_cache_filename( display, filter_index );
@@ -355,13 +387,13 @@ bool FeCache::load_filter_cache(
 
 	try
 	{
+		FeFilterIndexes indexes;
 		{	// block flushes archive
 			InputArchive archive( file );
-			archive( entry );
+			archive( indexes );
 		}
-
-		// Convert entry indexes back into pointers
-		entry.from_indexes( lookup );
+		// Restore indexes back into entries
+		indexes.index_to_entry( entry, lookup );
 		file.close();
 		return true;
 	}
@@ -376,8 +408,155 @@ bool FeCache::load_filter_cache(
 // -------------------------------------------------------------------------------------
 
 //
-// Store id for args used to load romlist
-// - Returns true if changed, indicating the romlist should be reload
+// Saves stats to cache file
+//
+bool FeCache::save_stats_cache(
+	std::string &emulator
+)
+{
+	if ( FeCache::stats_cache.find(emulator) == FeCache::stats_cache.end() ) return false;
+	std::string filename = get_stats_cache_filename( emulator );
+	if ( filename.empty() ) return false;
+	nowide::ofstream file( filename, std::ios::binary );
+	if ( !file.is_open() ) return false;
+
+	try
+	{
+		{	// block flushes archive
+			OutputArchive archive( file );
+			archive( FeCache::stats_cache[emulator] );
+		}
+		file.close();
+		return true;
+	}
+	catch (...)
+	{
+		file.close();
+		return false;
+	}
+}
+
+//
+// Loads cache file and updates stats
+//
+bool FeCache::load_stats_cache(
+	std::string &emulator
+)
+{
+	std::string filename = get_stats_cache_filename( emulator );
+	if ( !file_exists( filename ) ) return false;
+	nowide::ifstream file( filename, std::ios::binary );
+	if ( !file.is_open() ) return false;
+
+	try
+	{
+		{	// block flushes archive
+			InputArchive archive( file );
+			archive( FeCache::stats_cache[emulator] );
+		}
+		file.close();
+		return true;
+	}
+	catch ( ... )
+	{
+		file.close();
+		FeCache::stats_cache[emulator] = {};
+		return false;
+	}
+	return false;
+}
+
+// -------------------------------------------------------------------------------------
+
+//
+// Ensure stats cache entry exists for emulator
+// - If not, read all stats files and create one
+//
+bool FeCache::confirm_stats_cache(
+	const std::string &path,
+	std::string &emulator
+) {
+	// Exit if already loaded
+	if ( FeCache::stats_cache.find(emulator) != FeCache::stats_cache.end() ) return true;
+
+	// Exit if successfully loaded from cache
+	if ( load_stats_cache( emulator ) ) return true;
+
+	// Create new stats cache objectfor emulator
+	FeCache::stats_cache[emulator] = FeListStats();
+	std::vector<std::string> file_list;
+	std::string stats_path = path + emulator + "/";
+
+	// Exit if no stats to load
+	if ( !get_basename_from_extension( file_list, stats_path, FE_STAT_FILE_EXTENSION, true ) ) return false;
+
+	// Parse all stat files into cache object
+	std::string played_count;
+	std::string played_time;
+	for ( std::vector<std::string>::iterator itr=file_list.begin(); itr != file_list.end(); ++itr )
+	{
+		nowide::ifstream stat_file( (stats_path + *itr + FE_STAT_FILE_EXTENSION).c_str() );
+		if ( !stat_file.is_open() ) break;
+		played_count = "0";
+		played_time = "0";
+		if ( stat_file.good() ) getline( stat_file, played_count );
+		if ( stat_file.good() ) getline( stat_file, played_time );
+		FeCache::stats_cache[emulator].list[*itr] = FeStat( played_count, played_time );
+		stat_file.close();
+	}
+
+	// Save new stats cache for next time
+	save_stats_cache(emulator);
+	return true;
+}
+
+//
+// Load stats from cache to rominfo
+// - Always returns true to prevent callee attempting to load stats that dont exist
+//
+bool FeCache::get_stats_info(
+	const std::string &path,
+	std::vector<std::string> &rominfo
+) {
+	std::string emulator = rominfo[FeRomInfo::Emulator];
+	std::string romname = rominfo[FeRomInfo::Romname];
+
+	// Exit if no stats for this emulator, or this rom
+	if ( !confirm_stats_cache( path, emulator ) ) return true;
+	if ( FeCache::stats_cache[emulator].list.find(romname) == FeCache::stats_cache[emulator].list.end() ) return true;
+
+	// Copy stats to rominfo object
+	rominfo[FeRomInfo::PlayedCount] = FeCache::stats_cache[emulator].list[romname].played_count;
+	rominfo[FeRomInfo::PlayedTime] = FeCache::stats_cache[emulator].list[romname].played_time;
+	return true;
+}
+
+//
+// Save stats from rominfo to cache
+//
+bool FeCache::set_stats_info(
+	const std::string &path,
+	std::vector<std::string> &rominfo
+) {
+	std::string emulator = rominfo[FeRomInfo::Emulator];
+	std::string romname = rominfo[FeRomInfo::Romname];
+	std::string played_count = rominfo[FeRomInfo::PlayedCount];
+	std::string played_time = rominfo[FeRomInfo::PlayedTime];
+
+	// Exit if error creating cache for stat
+	if ( !confirm_stats_cache( path, emulator ) ) return true;
+
+	// Update stats in cache object, and save it
+	FeCache::stats_cache[emulator].list[romname] = FeStat( played_count, played_time );
+	save_stats_cache( emulator );
+	return true;
+}
+
+// -------------------------------------------------------------------------------------
+
+//
+// Store id for args used to load current romlist
+// - Returns true if changed, indicating the romlist should be reloaded
 //
 bool FeCache::set_romlist_args(
 	const std::string &path,
@@ -387,10 +566,10 @@ bool FeCache::set_romlist_args(
 	bool load_stats
 ) {
 	std::string args = path
-		+ "," + display.get_name()
-		+ "," + romlist_name
-		+ "," + ( group_clones ? "1" : "0" )
-		+ "," + ( load_stats ? "1" : "0" );
+		+ ";" + display.get_name()
+		+ ";" + romlist_name
+		+ ";" + ( group_clones ? "1" : "0" )
+		+ ";" + ( load_stats ? "1" : "0" );
 	bool changed = m_romlist_args != args;
 	m_romlist_args = args;
 	return changed;

--- a/src/fe_cache.hpp
+++ b/src/fe_cache.hpp
@@ -1,17 +1,65 @@
 #ifndef FE_CACHE_HPP
 #define FE_CACHE_HPP
 
+#ifndef FE_VERSION_NUM
+#define FE_VERSION_NUM 1
+#endif
+
 #include "fe_romlist.hpp"
 #include "fe_util.hpp"
 
 #include <algorithm>
 
+#include "cereal/cereal.hpp"
+#include <cereal/types/map.hpp>
+
+// A single stat item
+class FeStat
+{
+public:
+	std::string played_count;
+	std::string played_time;
+
+	FeStat() {}
+	FeStat( std::string count, std::string time ):
+		played_count( count ),
+		played_time( time )
+	{}
+
+	template<class Archive>
+	void serialize( Archive &archive, std::uint32_t const version )
+	{
+		if ( version != FE_VERSION_NUM ) throw "Invalid FeStat cache";
+		archive( played_count, played_time );
+	}
+};
+
+CEREAL_CLASS_VERSION( FeStat, FE_VERSION_NUM );
+
+// Holds a list of named stats
+class FeListStats
+{
+public:
+	std::map<std::string, FeStat> list = std::map<std::string, FeStat>{};
+
+	template<class Archive>
+	void serialize( Archive &archive, std::uint32_t const version )
+	{
+		if ( version != FE_VERSION_NUM ) throw "Invalid FeListStats cache";
+		archive( list );
+	}
+};
+
+CEREAL_CLASS_VERSION( FeListStats, FE_VERSION_NUM );
+
 class FeCache
 {
 private:
 
+	static std::vector<FeDisplayInfo>* m_displays;
 	static std::string m_config_path;
 	static std::string m_romlist_args;
+	static std::map<std::string, FeListStats> stats_cache;
 
 public:
 
@@ -19,7 +67,17 @@ public:
 		std::string path
 	);
 
+	static void set_displays(
+		std::vector<FeDisplayInfo>* displays
+	);
+
+	// ----------------------------------------------------------------------------------
+
 	static std::string get_romlist_cache_filename(
+		const std::string &romlist_name
+	);
+
+	static std::string get_globalfilter_cache_filename(
 		FeDisplayInfo &display
 	);
 
@@ -28,41 +86,21 @@ public:
 		int filter_index
 	);
 
-	// ----------------------------------------------------------------------------------
-
-	static void filter_list_to_indexes(
-		std::vector<int> &indexes,
-		std::vector<FeRomInfo*> &list
-	);
-
-	static void clone_group_to_indexes(
-		std::map<std::string, std::vector<int>> &indexes,
-		std::map<std::string, std::vector<FeRomInfo*>> &map
-	);
-
-	static void indexes_to_filter_list(
-		std::vector<FeRomInfo*> &list,
-		std::vector<int> &indexes,
-		std::vector<FeRomInfo*> &lookup
-	);
-
-	static void indexes_to_clone_group(
-		std::map<std::string, std::vector<FeRomInfo*>> &map,
-		std::map<std::string, std::vector<int>> &indexes,
-		std::vector<FeRomInfo*> &lookup
-	);
-
-	static std::vector<FeRomInfo*> get_romlist_lookup(
-		FeRomInfoListType &m_list
+	static std::string get_stats_cache_filename(
+		std::string &emulator
 	);
 
 	// ----------------------------------------------------------------------------------
+
+	static void invalidate_romlist(
+		const std::string &romlist_name
+	);
 
 	static void invalidate_display(
 		FeDisplayInfo &display
 	);
 
-	static void invalidate_romlist(
+	static void invalidate_globalfilter(
 		FeDisplayInfo &display
 	);
 
@@ -72,7 +110,7 @@ public:
 	);
 
 	static void invalidate_rominfo(
-		FeDisplayInfo &display,
+		const std::string &romlist_name,
 		FeRomInfo::Index target
 	);
 
@@ -81,11 +119,23 @@ public:
 	// ----------------------------------------------------------------------------------
 
 	static bool save_romlist_cache(
-		FeDisplayInfo &display,
+		const std::string &romlist_name,
 		FeRomList &romlist
 	);
 
 	static bool load_romlist_cache(
+		const std::string &romlist_name,
+		FeRomList &romlist
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	static bool save_globalfilter_cache(
+		FeDisplayInfo &display,
+		FeRomList &romlist
+	);
+
+	static bool load_globalfilter_cache(
 		FeDisplayInfo &display,
 		FeRomList &romlist
 	);
@@ -102,7 +152,34 @@ public:
 		FeDisplayInfo &display,
 		FeFilterEntry &entry,
 		int filter_index,
-		std::vector<FeRomInfo*> &lookup
+		std::map<int, FeRomInfo*> &lookup
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	static bool save_stats_cache(
+		std::string &emulator
+	);
+
+	static bool load_stats_cache(
+		std::string &emulator
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	static bool confirm_stats_cache(
+		const std::string &path,
+		std::string &emulator
+	);
+
+	static bool set_stats_info(
+		const std::string &path,
+		std::vector<std::string> &rominfo
+	);
+
+	static bool get_stats_info(
+		const std::string &path,
+		std::vector<std::string> &rominfo
 	);
 
 	// ----------------------------------------------------------------------------------

--- a/src/fe_info.cpp
+++ b/src/fe_info.cpp
@@ -22,6 +22,7 @@
 
 #include "fe_info.hpp"
 #include "fe_util.hpp"
+#include "fe_cache.hpp"
 #include <iostream>
 #include <sstream>
 
@@ -125,6 +126,10 @@ void FeRomInfo::load_stats( const std::string &path )
 	if ( path.empty() )
 		return;
 
+	// Attempt to load stats from cache, and exit if successful
+	if ( FeCache::get_stats_info( path, m_info ) )
+		return;
+
 	std::string filename = path + m_info[Emulator] + "/"
 		+ m_info[Romname] + FE_STAT_FILE_EXTENSION;
 	nowide::ifstream myfile( filename.c_str() );
@@ -157,6 +162,9 @@ void FeRomInfo::update_stats( const std::string &path, int count_incr, int playe
 
 	m_info[PlayedCount] = as_str( new_count );
 	m_info[PlayedTime] = as_str( new_time );
+
+	// Save stats to cache, and continue to save original stat file as well
+	FeCache::set_stats_info( path, m_info );
 
 	confirm_directory( path, m_info[Emulator] );
 	std::string filename = path + m_info[Emulator] + "/"

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -365,6 +365,7 @@ FeSettings::FeSettings( const std::string &config_path )
 		m_config_path += '/';
 
 	FeCache::set_config_path( m_config_path );
+	FeCache::set_displays( &m_displays );
 }
 
 void FeSettings::clear()
@@ -2420,17 +2421,10 @@ bool FeSettings::update_stats( int play_count, int play_time )
 	bool fixed = m_rl.fix_filters( m_displays[m_current_display], FeRomInfo::PlayedCount );
 	fixed |= m_rl.fix_filters( m_displays[m_current_display], FeRomInfo::PlayedTime );
 
-	// Invalidate the cache for all displays using stats in its rules/sort
+	// Invalidate all cache files using stats in their rules
 	std::string romlist_name = m_displays[m_current_display].get_romlist_name();
-	for ( int i=0; i<m_displays.size(); i++ )
-	{
-		if ( m_displays[i].get_romlist_name() == romlist_name )
-		{
-			FeCache::invalidate_rominfo( m_displays[i], FeRomInfo::PlayedCount );
-			FeCache::invalidate_rominfo( m_displays[i], FeRomInfo::PlayedTime );
-		}
-	}
-	FeCache::save_romlist_cache( m_displays[m_current_display], m_rl );
+	FeCache::invalidate_rominfo( romlist_name, FeRomInfo::PlayedCount );
+	FeCache::invalidate_rominfo( romlist_name, FeRomInfo::PlayedTime );
 
 	if ( fixed && ( &m_rl.lookup( filter_index, rom_index ) != rom ))
 	{


### PR DESCRIPTION
- Remove tags from the cache
- Stats now have their own cache, reduces romlist thrashing
- Master romlists now have their own cache, improves rebuild times
- Don't run or cache globalfilter if no rules for it