### PR TITLE
Fix invalid filter_size lookup

### DIFF
--- a/src/fe_romlist.hpp
+++ b/src/fe_romlist.hpp
@@ -210,8 +210,7 @@ public:
 		std::vector< std::pair<std::string, bool> > &tags_list ) const;
 	bool set_tag( FeRomInfo &rom, FeDisplayInfo &display, const std::string &tag, bool flag );
 
-	bool is_filter_empty( int filter_idx ) const { return m_filtered_list[filter_idx].filter_list.empty(); };
-	int filter_size( int filter_idx ) const { return (int)m_filtered_list[filter_idx].filter_list.size(); };
+	int filter_size( int filter_idx ) const { return ( filter_idx < m_filtered_list.size() ) ? (int)m_filtered_list[filter_idx].filter_list.size() : 0; };
 	const FeRomInfo &lookup( int filter_idx, int idx) const { return *(m_filtered_list[filter_idx].filter_list[idx]); };
 	FeRomInfo &lookup( int filter_idx, int idx) { return *(m_filtered_list[filter_idx].filter_list[idx]); };
 


### PR DESCRIPTION
`FeRomList` uses `display.get_filter_count` -> `m_filters.size()` as an unchecked index for `m_filtered_list`.
When a new Filter is added `m_filters` gets updated before `m_filtered_list` does.
A running layout that uses `filter_offset` will cause a segfault the moment the filter is created.
