### PR TITLE
Fix segfault on window close before input

### DIFF
--- a/src/fe_overlay.cpp
+++ b/src/fe_overlay.cpp
@@ -205,6 +205,7 @@ FeOverlay::FeOverlay( FeWindow &wnd,
 	m_fePresent( fep ),
 	m_overlay_is_on( false )
 {
+	clear_menu_command();
 	init();
 }
 

--- a/src/fe_overlay.hpp
+++ b/src/fe_overlay.hpp
@@ -111,7 +111,7 @@ public:
 	int tags_dialog( int default_sel, FeInputMap::Command extra_exit );
 
 	FeInputMap::Command get_menu_command() { return m_menu_command; }
-	void clear_menu_command() { m_menu_command = (FeInputMap::Command)-1; }
+	void clear_menu_command() { m_menu_command = FeInputMap::Command::Back; }
 
 	int common_list_dialog(
 		const std::string &title,

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -20,6 +20,9 @@
  *
  */
 
+// Enable to debug for UserConfig, also requires FE_DEBUG
+// #define FE_DEBUG_USERCONFIG
+
 #include "fe_vm.hpp"
 #include "fe_settings.hpp"
 #include "fe_present.hpp"
@@ -1473,10 +1476,11 @@ int FeVM::list_dialog(
 				extra_exit );
 	}
 
-	if ( m_overlay->get_menu_command() > 0 )
+	FeInputMap::Command menu_command = m_overlay->get_menu_command();
+	if ( menu_command != FeInputMap::Command::Back )
 	{
-		post_command( m_overlay->get_menu_command() );
 		m_overlay->clear_menu_command();
+		post_command( menu_command );
 	}
 
 	return retval;
@@ -1664,11 +1668,13 @@ public:
 			sqstd_register_stringlib( m_vm );
 			sqstd_register_systemlib( m_vm );
 
-#ifdef FE_DEBUG
-			// We purposefully do not set this in release builds, because we
-			// use this FeConfigVM to run scripts in config mode and often that means
-			// they crash and burn, and we don't want to be displaying the error messages
-			// for that.
+#if defined(FE_DEBUG) && defined(FE_DEBUG_USERCONFIG)
+			// THIS ERROR HANDLER IS INTENTIONALLY DISABLED
+			// FeConfigVM runs scripts in "config mode" with a limited environment
+			// purely to fetch the UserConfig class within for rendering layout options.
+			//
+			// Enable only to debug UserConfig issues, and expect messages such as:
+			// "AN ERROR HAS OCCURED [the index 'plugin' does not exist]"
 			sqstd_seterrorhandlers( m_vm );
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -931,10 +931,11 @@ int main(int argc, char *argv[])
 				// Overlay menu_commands are populated when the `QuickMenu` setting is true
 				// - They allow other menu commands to behave as a menu exit
 				// - Post the commands back onto the queue to switch to the next menu
-				if ( feOverlay.get_menu_command() > 0 )
+				FeInputMap::Command menu_command = feOverlay.get_menu_command();
+				if ( menu_command != FeInputMap::Command::Back )
 				{
-					feVM.post_command( feOverlay.get_menu_command() );
 					feOverlay.clear_menu_command();
+					feVM.post_command( menu_command );
 				}
 			}
 		}


### PR DESCRIPTION
`FeOverlay::m_menu_command` was not initialized.
Exiting AM before the main event loop recorded an input (easy to do in slow loading debug mode) would yield an invalid `get_menu_command`, and a segfault at `fe_vm.cpp:1418`.

Update to initialize this value.