### PR TITLE
Fix mouse movement handling

### DIFF
--- a/src/fe_input.hpp
+++ b/src/fe_input.hpp
@@ -73,7 +73,7 @@ public:
 	FeInputSingle( Type t, int code );
 
 	// Construct from an SFML event
-	FeInputSingle( const sf::Event &ev, const int mouse_thresh, const int joy_thresh );
+	FeInputSingle( const sf::Event &ev, const sf::IntRect &mc_rect, const int joy_thresh, bool has_focus );
 
 	// Construct from a config string
 	FeInputSingle( const std::string &str );
@@ -89,8 +89,6 @@ public:
 	// test the current state of the input that this object represents and return true if it is depressed,
 	// false otherwise.  Works for keys, buttons and joystick axes.  Does not work for mouse moves or wheels.
 	bool get_current_state( int joy_thresh ) const;
-
-	void init_mouse_window( FeWindow &wnd );
 
 	// Return the current position of the input that this object represents.
 	// Works for joystick axes
@@ -191,7 +189,7 @@ public:
 
 	FeInputMap();
 
-	Command map_input( const sf::Event &, const int mouse_thresh, const int joy_thresh );
+	Command map_input( const sf::Event &, const sf::IntRect &mc_rect, const int joy_thresh, bool has_focus );
 
 	Command input_conflict_check( const FeInputMapEntry &e );
 
@@ -221,6 +219,7 @@ public:
 		const std::string &fn );
 
 	void save( nowide::ofstream & ) const;
+	bool has_mouse_moves() const { return ( m_mmove_count > 0 ); };
 
 	static Command string_to_command( const std::string &s );
 
@@ -257,6 +256,8 @@ private:
 
 	// Config for mapping joysticks by name to specific id #s
 	std::vector< std::pair< int, std::string > > m_joy_config;
+
+	int m_mmove_count; // counter of whether mouse moves are mapped
 };
 
 class FeInputMapEntry
@@ -270,6 +271,7 @@ public:
 		const FeInputSingle &trigger=FeInputSingle() ) const;
 
 	std::string as_string() const;
+	bool has_mouse_move() const;
 
 	std::set < FeInputSingle > inputs;
 	FeInputMap::Command command;

--- a/src/fe_overlay.cpp
+++ b/src/fe_overlay.cpp
@@ -793,13 +793,14 @@ void FeOverlay::input_map_dialog(
 	// Make sure the appropriate mouse capture variables are set, in case
 	// the user has just changed the mouse threshold
 	//
-	m_feSettings.init_mouse_threshold( m_screen_size.x, m_screen_size.y );
+	sf::RenderWindow &rwnd = m_wnd.get_win();
+	m_feSettings.init_mouse_capture( &rwnd );
 
 	message.setSize( m_screen_size.x, m_screen_size.y );
 	message.setString( msg_str );
 
 	// Centre the mouse in case the user is mapping a mouse move event
-	sf::Mouse::setPosition( sf::Vector2i( m_screen_size.x / 2, m_screen_size.y / 2 ), m_wnd.get_win() );
+	sf::Mouse::setPosition( m_screen_size / 2, rwnd );
 
 	// empty the window event queue
 	while ( const std::optional ev = m_wnd.pollEvent() )
@@ -815,9 +816,9 @@ void FeOverlay::input_map_dialog(
 	bool multi_mode=false; // flag if we are checking for multiple inputs.
 	bool done=false;
 
-	int mouse_thresh;
+	sf::IntRect mc_rect;
 	int joy_thresh;
-	m_feSettings.get_input_config_metrics( mouse_thresh, joy_thresh );
+	m_feSettings.get_input_config_metrics( mc_rect, joy_thresh );
 
 	std::set < std::pair<int,int> > joystick_moves;
 	FeInputMapEntry entry;
@@ -839,7 +840,7 @@ void FeOverlay::input_map_dialog(
 					done = true;
 				else
 				{
-					FeInputSingle single( ev.value(), mouse_thresh, joy_thresh );
+					FeInputSingle single( ev.value(), mc_rect, joy_thresh, rwnd.hasFocus() );
 					if ( single.get_type() != FeInputSingle::Unsupported )
 					{
 						if (( ev->is<sf::Event::KeyPressed>() )
@@ -1447,6 +1448,8 @@ bool FeOverlay::event_loop( FeEventLoopCtx &ctx )
 				if (( c != FeInputMap::LAST_COMMAND )
 						&& ( c == ctx.extra_exit ))
 					c = FeInputMap::Exit;
+
+				if ( m_feSettings.test_mouse_wrap() ) m_feSettings.wrap_mouse();
 
 				switch( c )
 				{

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -210,7 +210,8 @@ private:
 	FeLayoutInfo m_intro_params;
 	FeLayoutInfo m_current_layout_params; // copy of current layout params (w/ per display params as well)
 	FeLayoutInfo m_display_menu_per_display_params; // stores only the 'per_display' params for the display menu
-	int m_window_mouse_thresh;
+	sf::IntRect m_mousecap_rect;
+	sf::RenderWindow *m_rwnd;
 
 	int m_current_display; // -1 if we are currently showing the 'displays menu' w/ custom layout
 	FeBaseConfigurable *m_current_config_object;
@@ -321,7 +322,7 @@ public:
 
 	FeInputMap::Command map_input( const std::optional<sf::Event> &e );
 
-	void get_input_config_metrics( int &mouse_thresh, int &joy_thresh );
+	void get_input_config_metrics( sf::IntRect &mousecap_rect, int &joy_thresh );
 	FeInputMap::Command input_conflict_check( const FeInputMapEntry &e );
 
 	// for use with Up, Down, Left, Right, Back commands to get what they are actually mapped to
@@ -399,7 +400,10 @@ public:
 	bool select_last_launch();
 	bool is_last_launch( int filter_offset, int index_offset );
 	int get_joy_thresh() const { return m_joy_thresh; }
-	void init_mouse_threshold( int window_x, int window_y );
+	void init_mouse_capture( sf::RenderWindow *window );
+	bool has_mouse_moves() const { return m_inputmap.has_mouse_moves(); }
+	bool test_mouse_wrap() const;
+	void wrap_mouse();
 
 	// prepares for emulator launch by setting various tracking variables (last launch, etc)
 	// and determining the correct executable, command line parameters and working directory to use

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1224,8 +1224,6 @@ bool FeVM::on_new_layout()
 			<< " (" << filename << ")" << std::endl;
 	}
 
-	FeInputSingle().init_mouse_window( m_window );
-
 	// To avoid frame delay of nested surfaces we have to sort them here
 	// so the most nested ones are redrawn first
 	std::stable_sort( m_texturePool.begin(), m_texturePool.end(), nesting_compare );

--- a/src/fe_window.hpp
+++ b/src/fe_window.hpp
@@ -52,7 +52,6 @@ private:
 #endif
 	int m_win_mode;
 	bool m_mouse_outside = true;
-	sf::Vector2i m_mouse_pos;
 	sf::Image m_logo_image;
 
 public:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -362,6 +362,11 @@ int main(int argc, char *argv[])
 				if ( ev->is<sf::Event::Closed>() )
 					exit_selected = true;
 
+				else if ( feSettings.test_mouse_wrap() )
+				{
+					feSettings.wrap_mouse();
+				}
+
 				else if ( ev->is<sf::Event::KeyReleased>() ||
 							ev->is<sf::Event::MouseButtonReleased>() ||
 							ev->is<sf::Event::JoystickButtonReleased>() )


### PR DESCRIPTION
Reinstated the capture box method used prior to the last mouse movement update.
(`MouseMovedRaw` is perfect for this task but only available in Win+Linux, hence this reversion).

Fixes issue #107 
Since the mouse can no longer escape the window, `ALT+TAB` must be used to change focus.