### PR TITLE
Refactor builtin menu elements

### DIFF
--- a/src/fe_base.cpp
+++ b/src/fe_base.cpp
@@ -38,7 +38,7 @@ extern "C"
 
 const char *FE_NAME         = FE_NAME_D;
 const char *FE_COPYRIGHT    = FE_NAME_D " " FE_VERSION_D " " FE_BUILD_D "\n" \
-	"Copyright (c) 2013-2025 Andrew Mickelson & Radek Dutkiewicz";
+	"Copyright © 2013-2025 Andrew Mickelson & Radek Dutkiewicz";
 const char *FE_VERSION      = FE_VERSION_D;
 
 const char *FE_BUILD_NUMBER  = FE_BUILD_D;

--- a/src/fe_listbox.cpp
+++ b/src/fe_listbox.cpp
@@ -78,6 +78,12 @@ FeListBox::FeListBox(
 {
 }
 
+FeListBox::FeListBox( FePresentableParent &p )
+	: FeListBox( p, 0, 0, 0, 0 )
+{
+    m_scripted = false;
+}
+
 void FeListBox::setFont( const sf::Font &f )
 {
 	m_base_text.setFont( f );

--- a/src/fe_listbox.hpp
+++ b/src/fe_listbox.hpp
@@ -58,6 +58,13 @@ public:
 			unsigned int characterSize,
 			int rows );
 
+	// Constructor for use in overlay.  sets m_scripted to false
+	FeListBox( FePresentableParent &p );
+
+	FeListBox( const FeListBox & );
+
+	FeListBox &operator=( const FeListBox & );
+
 	void setFont( const sf::Font & );
 	sf::Vector2f getPosition() const;
 	void setPosition( const sf::Vector2f & );
@@ -157,9 +164,6 @@ public:
 	void set_format_string( const char *s );
 	int get_selected_row() const;
 private:
-	FeListBox( const FeListBox & );
-	FeListBox &operator=( const FeListBox & );
-
 	void internalSetText( const int index );
 
 

--- a/src/fe_overlay.hpp
+++ b/src/fe_overlay.hpp
@@ -27,6 +27,8 @@
 #include "fe_present.hpp"
 #include "fe_window.hpp"
 #include "fe_config.hpp"
+#include "fe_text.hpp"
+#include "fe_listbox.hpp"
 
 class FeSettings;
 class FeInputMapEntry;
@@ -43,26 +45,79 @@ private:
 	FeWindow &m_wnd;
 	FeSettings &m_feSettings;
 	FePresent &m_fePresent;
-	sf::Color m_bg_colour;
-	sf::Color m_edge_bg_color;
-	sf::Color m_edge_line_colour;
-	sf::Color m_sel_focus_colour;
-	sf::Color m_sel_text_colour;
-	sf::Color m_sel_blur_colour;
-	sf::Color m_header_text_colour;
-	sf::Color m_footer_text_colour;
-	sf::Color m_text_colour;
+
+	sf::Color m_bg_color;
+	sf::Color m_text_color;
+	sf::Color m_theme_color;
+	sf::Color m_letterbox_color;
+	sf::Color m_border_color;
+	sf::Color m_focus_color;
+	sf::Color m_blur_color;
+
 	bool m_overlay_is_on;
-	sf::Vector2i m_screen_size;
+	sf::Vector2f m_screen_size;
+	sf::Vector2f m_screen_pos;
 	sf::Vector2f m_text_scale;
-	int m_text_size;
-	int m_header_size;
-	int m_footer_size;
-	int m_edge_size;
-	int m_line_size;
-	int m_fade_alpha;
+	int m_index_width;
+	int m_list_char_size;
+	int m_header_char_size;
+	int m_footer_char_size;
+	float m_row_height_scale;
+	int m_letterbox_top_height;
+	int m_letterbox_bottom_height;
+	int m_letterbox_margin;
+	int m_text_margin;
+	int m_footer_width;
+	int m_border_thickness;
+	int m_enable_alpha;
+	int m_disable_alpha;
 	const sf::Font *m_font;
 	FeInputMap::Command m_menu_command;
+
+	enum LayoutStyle {
+		None	= 0,
+		Top		= 1 << 0,
+		Middle	= 1 << 1,
+		Bottom	= 1 << 2,
+		Left	= 1 << 3,
+		Centre	= 1 << 4,
+		Right	= 1 << 5,
+		Body	= 1 << 6,
+		Full	= 1 << 7,
+		Large	= 1 << 8,
+		Single	= 1 << 9
+	};
+
+	sf::RectangleShape layout_background();
+	sf::RectangleShape layout_letterbox( int style = LayoutStyle::None );
+	sf::RectangleShape layout_border( int style = LayoutStyle::None );
+	FeTextPrimitive layout_header( int style = LayoutStyle::None );
+	FeTextPrimitive layout_footer();
+	FeTextPrimitive layout_message( int style = LayoutStyle::None );
+	FeTextPrimitive layout_index( int style = LayoutStyle::None );
+	sf::Sprite layout_logo( sf::Texture &texture );
+	FeListBox layout_list( int style = LayoutStyle::None );
+
+    int list_row_height( int style );
+
+	bool text_index(
+		FeListBox &list,
+		FeTextPrimitive &text,
+		std::vector<std::string> &values,
+		int index
+	);
+
+	enum LayoutFocus {
+		Select		= 1 << 0,
+		Edit		= 1 << 1,
+		Disabled	= 1 << 2
+	};
+
+	bool layout_focus(
+		FeListBox &label_list,
+		FeListBox &value_list,
+		int focus = LayoutFocus::Select
+	);
 
 	FeOverlay( const FeOverlay & );
 	FeOverlay &operator=( const FeOverlay & );
@@ -96,7 +151,7 @@ public:
 	enum SelCode {
 		ExitToDesktop = -999
 	};
-	
+
 	FeOverlay( FeWindow &wnd,
 		FeSettings &fes,
 		FePresent &fep );

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -321,7 +321,7 @@ FeVM::FeVM( FeSettings &fes, FeWindow &wnd, FeMusic &ambient_sound, bool console
 
 FeVM::~FeVM()
 {
-	clear();
+	clear_handlers();
 
 	//
 	// Save the "non-volatile" squirrel table (fe.nv) to a file now
@@ -391,15 +391,20 @@ bool FeVM::poll_command( FeInputMap::Command &c, std::optional<sf::Event> &ev, b
 	return false;
 }
 
-void FeVM::clear()
+void FeVM::clear_handlers()
 {
 	FePresent::clear();
-	m_overlay->init();
 	m_last_ui_cmd = sf::Time();
 	m_ticks.clear();
 	m_trans.clear();
 	m_sig_handlers.clear();
 	clear_commands();
+}
+
+void FeVM::clear()
+{
+	clear_handlers();
+	m_overlay->init();
 }
 
 void FeVM::add_ticks_callback( Sqrat::Object func, const char *slot )

--- a/src/fe_vm.hpp
+++ b/src/fe_vm.hpp
@@ -121,6 +121,7 @@ public:
 	void clear_commands();
 	void post_command( FeInputMap::Command c );
 	bool poll_command( FeInputMap::Command &c, std::optional<sf::Event> &ev, bool &from_ui );
+	void clear_handlers();
 	void clear(); // override of base class clear()
 
 	void update_to_new_list( int var=0, bool reset_display=false );

--- a/src/fe_window.cpp
+++ b/src/fe_window.cpp
@@ -489,8 +489,10 @@ void FeWindow::initial_create()
 	if ( m_fes.has_mouse_moves() )
 		sf::Mouse::setPosition( wsize / 2, *m_window );
 
+	// Logo sf::Image is kept here to prevent DRM build crashes
+	// This ensures its disposal on window destruction - DO NOT MOVE!
 	std::vector<unsigned char> logo_data = base64_decode( _binary_resources_images_Logo_png );
-	if ( m_logo_image.loadFromMemory( logo_data.data(), logo_data.size() ));
+	std::ignore = m_logo_image.loadFromMemory( logo_data.data(), logo_data.size() );
 }
 
 void launch_callback( void *o )
@@ -780,14 +782,14 @@ void FeWindow::close()
 	if ( m_window )
 	{
 		m_window->display(); // Crashing on Linux workaround
-		
+
 		// Window may already be closed on_exit, so save position here instead
 		if ( is_windowed_mode( m_win_mode ) && m_fes.get_window_args().size() != 4 )
 		{
 			FeWindowPosition win_pos( m_window->getPosition(), m_window->getSize() );
 			win_pos.save( m_fes.get_config_dir() + FeWindowPosition::FILENAME );
 		}
-		
+
 		m_window->close();
 	}
 }


### PR DESCRIPTION
- Consolidate menu styles
- Add minimal dialog for "Layout Preview" option
- List index displayed in "Layout Preview" lists

Other changes
- Lists forced to have an ODD number of elements, so the selection bar is displayed in the middle (rather than offset).
- Message element for input-entry and confirm-dialog now in same place, and more towards middle
- Confirm-dialog inputs more towards middle, slightly larger, and in same place as input-entry

![image](https://github.com/user-attachments/assets/8aa8555d-cb83-42c6-9341-9c5adcee3ca7)
![image](https://github.com/user-attachments/assets/fcaead92-e2e4-44be-a651-7ecde101c580)
![image](https://github.com/user-attachments/assets/daefa0da-4be0-4c0c-9f23-cfade2b7b21b)
![image](https://github.com/user-attachments/assets/d87dd225-6773-4691-8812-0ededf765915)
![image](https://github.com/user-attachments/assets/3daf4f06-3088-4456-a0c8-b4c2d4d46fd4)

The index appears on the currently selected list (left or right side).
![image](https://github.com/user-attachments/assets/f25bf762-2eb2-49ab-8086-4f9ee4b0c052)
![image](https://github.com/user-attachments/assets/8aa0340e-de92-4920-a147-7e83c4e93695)