### PR TITLE
Fix Filter Size Value

### DIFF
--- a/src/fe_romlist.cpp
+++ b/src/fe_romlist.cpp
@@ -663,6 +663,7 @@ void FeRomList::create_filters(
 		// Attempt to load filter from cache
 		if ( FeCache::load_filter_cache( display, m_filtered_list[i], i, lookup ) )
 		{
+			display.get_filter( i )->set_size( m_filtered_list[i].filter_list.size() );
 			filters_cached++;
 			continue;
 		}


### PR DESCRIPTION
Fixed `fe.filters[0].size` not being populated from cache.

Gets set in `build_single_filter_list` which is skipped during cache load.