### PR TITLE
Fix Duplicate Init Calls

### DIFF
--- a/src/fe_cache.cpp
+++ b/src/fe_cache.cpp
@@ -29,7 +29,6 @@ const std::string FE_EMPTY_STRING;
 
 std::vector<FeDisplayInfo>* FeCache::m_displays = {};
 std::string FeCache::m_config_path = "";
-std::string FeCache::m_romlist_args = "";
 
 // Global storage for [emulator][romname] stats
 std::map<std::string, FeListStats> FeCache::stats_cache = std::map<std::string, FeListStats>{};
@@ -184,7 +183,6 @@ void FeCache::invalidate_globalfilter(
 )
 {
 #ifdef FE_CACHE_ENABLE
-	invalidate_romlist_args();
 	std::string filename = get_globalfilter_cache_filename( display );
 	if ( file_exists( filename ) ) delete_file( filename );
 #endif
@@ -199,7 +197,6 @@ void FeCache::invalidate_filter(
 )
 {
 #ifdef FE_CACHE_ENABLE
-	invalidate_romlist_args();
 	std::string filename = get_filter_cache_filename( display, filter_index );
 	if ( file_exists( filename ) ) delete_file( filename );
 #endif
@@ -696,39 +693,4 @@ bool FeCache::set_stats_info(
 #else
 	return false;
 #endif
-}
-
-// -------------------------------------------------------------------------------------
-
-//
-// Store id for args used to load current romlist
-// - Returns true if changed, indicating the romlist should be reloaded
-//
-bool FeCache::set_romlist_args(
-	const std::string &path,
-	const std::string &romlist_name,
-	FeDisplayInfo &display,
-	bool group_clones,
-	bool load_stats
-) {
-#ifdef FE_CACHE_ENABLE
-	std::string args = path
-		+ ";" + display.get_name()
-		+ ";" + romlist_name
-		+ ";" + ( group_clones ? "1" : "0" )
-		+ ";" + ( load_stats ? "1" : "0" );
-	bool changed = m_romlist_args != args;
-	m_romlist_args = args;
-	return changed;
-#else
-	return true;
-#endif
-}
-
-//
-// Clear stored args id, forcing a reload on next load_romlist
-//
-void FeCache::invalidate_romlist_args()
-{
-	m_romlist_args = "";
 }

--- a/src/fe_cache.hpp
+++ b/src/fe_cache.hpp
@@ -58,7 +58,6 @@ private:
 
 	static std::vector<FeDisplayInfo>* m_displays;
 	static std::string m_config_path;
-	static std::string m_romlist_args;
 	static std::map<std::string, FeListStats> stats_cache;
 
 public:
@@ -117,8 +116,6 @@ public:
 		const std::string &romlist_name,
 		FeRomInfo::Index target
 	);
-
-	static void invalidate_romlist_args();
 
 	// ----------------------------------------------------------------------------------
 
@@ -198,16 +195,6 @@ public:
 	static bool get_stats_info(
 		const std::string &path,
 		std::vector<std::string> &rominfo
-	);
-
-	// ----------------------------------------------------------------------------------
-
-	static bool set_romlist_args(
-		const std::string &path,
-		const std::string &romlist_name,
-		FeDisplayInfo &display,
-		bool group_clones,
-		bool load_stats
 	);
 
 };

--- a/src/fe_config.cpp
+++ b/src/fe_config.cpp
@@ -1289,10 +1289,9 @@ void FeDisplayMenuEditMenu::get_options( FeConfigContext &ctx )
 	std::string default_str;
 	ctx.fe_settings.get_translation( "Default", default_str );
 
-	std::string layout = ctx.fe_settings.get_info( FeSettings::MenuLayout );
-
-	if ( layout.empty() )
-		layout = default_str;
+	std::string layout = ctx.fe_settings.has_custom_displays_menu()
+		? ctx.fe_settings.get_info( FeSettings::MenuLayout )
+		: default_str;
 
 	std::vector<std::string> layouts;
 	ctx.fe_settings.get_layouts_list( layouts ); // this sorts the list

--- a/src/fe_overlay.cpp
+++ b/src/fe_overlay.cpp
@@ -934,7 +934,7 @@ bool FeOverlay::edit_game_dialog( int default_sel, FeInputMap::Command extra_exi
 		// If invoked when showing the "displays menu", edit the
 		// display that is currently selected
 		//
-		int index = m_feSettings.display_menu_get_current_selection_as_absolute_display_index();
+		int index = m_feSettings.get_selected_display_index();
 
 		if ( index >= 0 )
 		{
@@ -1000,12 +1000,10 @@ bool FeOverlay::layout_options_dialog(
 		display = NULL;
 		per_display = &m_feSettings.get_display_menu_per_display_params();
 
-		std::string lname = m_feSettings.get_info( FeSettings::MenuLayout );
-
-		if ( lname.empty() )
+		if ( !m_feSettings.has_custom_displays_menu() )
 			return false;
 
-		layout = &m_feSettings.get_layout_config( lname );
+		layout = &m_feSettings.get_layout_config( m_feSettings.get_info( FeSettings::MenuLayout ) );
 	}
 	else
 	{
@@ -1026,10 +1024,8 @@ bool FeOverlay::layout_options_dialog(
 	if ( settings_changed )
 	{
 		// Save the updated settings to disk
+		// main.cpp calls load_layout() upon return to show the updated settings
 		m_feSettings.save();
-
-		// This forces the display to reinitialize with the updated settings
-		m_feSettings.set_display( m_feSettings.get_current_display_index() );
 	}
 
 	return settings_changed;

--- a/src/fe_romlist.cpp
+++ b/src/fe_romlist.cpp
@@ -172,9 +172,6 @@ FeRomList::~FeRomList()
 
 void FeRomList::init_as_empty_list()
 {
-	// Romlist will require reloading after clearing, so invalidate the arg cache
-	FeCache::invalidate_romlist_args();
-
 	m_romlist_name.clear();
 	m_list.clear();
 	m_filtered_list.clear();
@@ -238,10 +235,6 @@ bool FeRomList::load_romlist( const std::string &path,
 	bool group_clones,
 	bool load_stats	)
 {
-	// Exit early if arguments have not changed - prevents things like layout option edits re-loading the romlist
-	if (!FeCache::set_romlist_args(path, romlist_name, display, group_clones, load_stats))
-		return true;
-
 	sf::Clock load_timer;
 	std::string romlist_path = path + romlist_name + FE_ROMLIST_FILE_EXTENSION;
 	time_t mtime = file_mtime( romlist_path );
@@ -481,11 +474,12 @@ bool FeRomList::load_romlist( const std::string &path,
 	}
 
 	FeLog() << " - Loaded romlist '" << m_romlist_name << "' in " << load_timer.getElapsedTime().asMilliseconds() << " ms (";
-	if ( !has_global_rules ) FeLog() << m_list.size() << " entries from romlist";
-	if ( loaded_globalfilter_cache ) FeLog() << m_list.size() << " entries from cache";
+	if ( !has_global_rules && !loaded_romlist_cache ) FeLog() << m_list.size() << " entries from romlist";
+	if ( loaded_romlist_cache ) FeLog() << m_list.size() << " entries from romlist cache";
 	if ( has_global_rules && !loaded_globalfilter_cache ) FeLog() << m_list.size() << " kept, " << global_filtered_out_count << " discarded";
-	if ( saved_globalfilter_cache ) FeLog() << ", cached globalfilter";
+	if ( loaded_globalfilter_cache ) FeLog() << m_list.size() << " entries from globalfilter cache";
 	if ( saved_romlist_cache ) FeLog() << ", cached romlist";
+	if ( saved_globalfilter_cache ) FeLog() << ", cached globalfilter";
 	FeLog() << ")" << std::endl;
 
 	create_filters( display );

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -114,6 +114,7 @@ public:
 
 	static std::vector<std::string> uiColorTokens;
 	static std::vector<std::string> uiColorDispTokens;
+	void load_layout_params();
 
 	// These values must align with `FeSettings::configSettingStrings`
 	enum ConfigSettingIndex
@@ -213,7 +214,8 @@ private:
 	sf::IntRect m_mousecap_rect;
 	sf::RenderWindow *m_rwnd;
 
-	int m_current_display; // -1 if we are currently showing the 'displays menu' w/ custom layout
+	int m_current_display; // The index of the current display, -1 if showing a custom displays_menu
+	int m_selected_display; // The index of the displays_menu selected display, -1 if EXIT is selected. Equals m_current_display if displays_menu not shown.
 	FeBaseConfigurable *m_current_config_object;
 	int m_ssaver_time;
 	int m_last_launch_display;
@@ -224,8 +226,6 @@ private:
 	int m_joy_thresh;		// [1..100], 100=least sensitive
 	int m_mouse_thresh;	// [1..100], 100=least sensitive
 	int m_current_search_index; // used when custom searching
-	int m_current_display_index; // used as an index of currently selected display in displays menu
-	int m_actual_display_index; // The most recent display index that was selected in the displays menu
 	bool m_displays_menu_exit;
 	bool m_hide_brackets;
 	bool m_group_clones;
@@ -371,7 +371,7 @@ public:
 	bool back_displays_available() { return !m_display_stack.empty(); };
 
 	int get_current_display_index() const;
-	int get_actual_display_index() const;
+	int get_selected_display_index() const;
 	int get_display_index_from_name( const std::string &name ) const;
 	int displays_count() const;
 
@@ -602,13 +602,11 @@ public:
 	bool get_info_bool( int index ) const;
 	bool set_info( int index, const std::string & );
 
+	bool has_custom_displays_menu();
 	void get_displays_menu( std::string &title,
 		std::vector<std::string> &names,
 		std::vector<int> &indices,
 		int &current_idx ) const;
-
-	// Used only when Edit Game is pressed in Displays Menu
-	int display_menu_get_current_selection_as_absolute_display_index();
 
 	FeDisplayInfo *get_display( int index );
 	FeDisplayInfo *create_display( const std::string &n );

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -509,6 +509,9 @@ bool FeVM::on_new_layout()
 {
 	using namespace Sqrat;
 
+	// Loaded layout settings prior to starting the layout
+	m_feSettings->load_layout_params();
+	
 	const FeLayoutInfo &layout_params
 		= m_feSettings->get_current_config( FeSettings::Current );
 


### PR DESCRIPTION
- Fixed `Initializing display` called twice on app load
- Fixed `Initializing display` called twice after config change & menu exit
- Fixed `Loaded layout` called twice on layout option change in Layout-Preview mode
- Removed `load_intro` `get_startup_mode` switch, falls through to common `get_present_state` section
- Removed `set_romlisit_args` check since duplicate calls now fixed
- Fix `LaunchLastGame > set_display > Restart` incorrect display issue
- Prevent `LaunchLastGame` firing after manually starting `Intro`
- Refactored display indexes (again it seems).
  - `m_current_display` - The index of the current display, -1 if showing a custom displays_menu (same as before)
  - `m_selected_display` - The index of the displays_menu selected display, -1 if EXIT is selected. Equals m_current_display if displays_menu not shown. (replaces `current` and `actual` display index).
- `ShowDisplaysMenu` (with custom displays_menu) starts on previous selection without having to visit it first
- `Initializing display` message now printed for custom displays_menu layouts