### PR TITLE
Update Window Commandline To Accept Negative Values

### DIFF
--- a/src/fe_cmdline.cpp
+++ b/src/fe_cmdline.cpp
@@ -102,7 +102,7 @@ void process_args( int argc, char *argv[],
 				}
 				else
 				{
-					FeLog() << "Unreconized loglevel: " << argv[next_arg] << std::endl;
+					FeLog() << "Unrecognized loglevel: " << argv[next_arg] << std::endl;
 					exit( 1 );
 				}
 			}
@@ -279,15 +279,15 @@ void process_args( int argc, char *argv[],
 		{
 			next_arg++;
 
-			for ( ; next_arg < argc; next_arg++ )
+			for ( ; (next_arg < argc) && (window_args.size() < 4); next_arg++ )
 			{
-				if ( argv[next_arg][0] == '-' )
-					break;
-
-				// Window args may be space or comma delimited
+				// Window delimiter may be space (reads multiple args) or comma (splits single arg)
+				// - Reads from argv until 4 window args are found
 				std::istringstream iss(argv[next_arg]);
 				std::string s;
-				while ( std::getline( iss, s, ',' ) ) window_args.push_back( atoi(s.c_str()) );
+				while ( std::getline( iss, s, ',' ) ) {
+					window_args.push_back( atoi(s.c_str()) );
+				}
 			}
 		}
 #ifndef SFML_SYSTEM_WINDOWS

--- a/src/fe_window.cpp
+++ b/src/fe_window.cpp
@@ -420,7 +420,7 @@ void FeWindow::initial_create()
 	sf::ContextSettings ctx;
 	ctx.antiAliasingLevel = m_fes.get_antialiasing();
 
-	m_window->create( vm, "Attract-Mode Plus", style_map[ m_win_mode ], state_map[ m_win_mode ], ctx );
+	m_window->create( vm, FE_NAME, style_map[ m_win_mode ], state_map[ m_win_mode ], ctx );
 
 	// On Windows Vista and above all non fullscreen window modes
 	// go through DWM. We have to disable vsync
@@ -431,7 +431,7 @@ void FeWindow::initial_create()
 	m_window->setVerticalSyncEnabled(true);
 #endif
 	m_window->setKeyRepeatEnabled(false);
-	m_window->setMouseCursorVisible(false);
+	m_window->setMouseCursorVisible( is_windowed_mode( m_win_mode ));
 	m_window->setJoystickThreshold( 1.0 );
 
 #ifndef SFML_SYSTEM_MACOS
@@ -459,9 +459,10 @@ void FeWindow::initial_create()
 
 	// Known issue: Linux Mint 18.3 Cinnamon w/ SFML 2.5.1, position isn't being set
 	// (Window always winds up at 0,0)
+	// There is currently no way to create window at position, or create hidden then reveal
 	m_window->setPosition( wpos );
 
-	FeDebug() << "Created Attract-Mode Window: " << wsize.x << "x" << wsize.y << " @ "
+	FeDebug() << "Created " << FE_NAME << " Window: " << wsize.x << "x" << wsize.y << " @ "
 		<< wpos.x << "," << wpos.y << " [OpenGL surface: "
 		<< vm.size.x << "x" << vm.size.y << " bpp=" << vm.bitsPerPixel << "]" << std::endl;
 


### PR DESCRIPTION
Now you can use the command-line to position AM to the left of the main screen:
`attractplus.exe -w -100,0,500,500`

- `-w` will consume the following `-` to allow negative numbers
- Prevent hiding mouse on window creation if window-mode
- Updated window title to use constant