### PR TITLE
Update image anchor and aspect ratio

### DIFF
--- a/src/fe_image.hpp
+++ b/src/fe_image.hpp
@@ -327,6 +327,8 @@ public:
 
 	void texture_changed( FeBaseTextureContainer *new_tex=NULL );
 
+	bool get_auto_width() const;
+	bool get_auto_height() const;
 	float get_origin_x() const;
 	float get_origin_y() const;
 	int get_anchor_type() const;
@@ -356,6 +358,8 @@ public:
 	float get_volume() const;
 	float get_border_scale() const;
 
+	void set_auto_width( bool w );
+	void set_auto_height( bool h );
 	void set_origin_x( float x );
 	void set_origin_y( float y );
 	void set_anchor( float x, float y );
@@ -393,6 +397,13 @@ public:
 	bool fix_masked_image();
 	FePresentableParent *get_presentable_parent();
 
+	// Override from base class:
+	float get_width() const;
+	float get_height() const;
+	void set_width( float w );
+	void set_height( float h );
+	void set_pos(float x, float y, float w, float h);
+
 	//
 	// Callback functions for use with surface objects
 	//
@@ -414,6 +425,7 @@ protected:
 	FeSprite m_sprite;
 	sf::Vector2f m_pos;
 	sf::Vector2f m_size;
+	sf::Vector2u m_auto_size;
 	sf::Vector2f m_scale;
 	sf::Vector2f m_origin;
 	sf::Vector2f m_rotation_origin;

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -722,6 +722,10 @@ bool FeVM::on_new_layout()
 
 	fe.Bind( _SC("Image"),
 		DerivedClass<FeImage, FeBasePresentable, NoConstructor>()
+		.Prop(_SC("width"), &FeImage::get_width, &FeImage::set_width )
+		.Prop(_SC("height"), &FeImage::get_height, &FeImage::set_height )
+		.Prop(_SC("auto_width"), &FeImage::get_auto_width, &FeImage::set_auto_width )
+		.Prop(_SC("auto_height"), &FeImage::get_auto_height, &FeImage::set_auto_height )
 		.Prop(_SC("origin_x"), &FeImage::get_origin_x, &FeImage::set_origin_x )
 		.Prop(_SC("origin_y"), &FeImage::get_origin_y, &FeImage::set_origin_y )
 		.Prop(_SC("anchor"), &FeImage::get_anchor_type, &FeImage::set_anchor_type )
@@ -768,6 +772,7 @@ bool FeVM::on_new_layout()
 		.Func(_SC("rawset_index_offset"), &FeImage::rawset_index_offset )
 		.Func(_SC("rawset_filter_offset"), &FeImage::rawset_filter_offset )
 		.Func(_SC("fix_masked_image"), &FeImage::fix_masked_image )
+		.Overload<void (FeImage::*)(float, float, float, float)>(_SC("set_pos"), &FeImage::set_pos)
 
 		//
 		// Surface-specific functionality:


### PR DESCRIPTION
- Anchor now works on auto-sized images
- Preserve aspect ratio now works with a single dimension
- Negative image sizes now flip image about anchor
- Added auto_width and auto_height properties

Attached test [layout.zip](https://github.com/user-attachments/files/20654102/layout.zip)
- Prev/Next Page - Change test
- Select - Change animation

Breaking changes:
- Setting image size to zero now actually sets it to zero (except during creation, where 0 = auto-size)
- Setting image size negative flips/mirrors the image, instead of being ignored
- Using auto_width or auto_height will fill the corresponding width or height with the actual size