### PR TITLE
Fix back button behaviour in Displays Menu

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -614,6 +614,19 @@ int main(int argc, char *argv[])
 				{
 				case FeInputMap::Exit:
 					{
+						if ( feSettings.get_startup_mode() != FeSettings::ShowDisplaysMenu && feSettings.has_custom_displays_menu() )
+						{
+							int display_index = feSettings.get_current_display_index();
+							if (display_index == -1 && last_display_index != -1)
+							{
+								display_index = last_display_index;
+								last_display_index = -1;
+								feSettings.set_display( display_index );
+								feVM.load_layout( true );
+								redraw=true;
+								break;
+							}
+						}
 						if ( feOverlay.common_exit() )
 							exit_selected=true;
 


### PR DESCRIPTION
When Displays Menu has custom layout set and Startup Mode is not set as Show Displays Menu after pressing back button return to previously active Display instead of exiting AM+