### PR TITLE
Update romlist sorting

### DIFF
--- a/src/fe_romlist.hpp
+++ b/src/fe_romlist.hpp
@@ -60,6 +60,7 @@ public:
 
 	bool operator()( const FeRomInfo &obj1, const FeRomInfo &obj2 ) const;
 
+	std::string get_trimmed_title( const std::string &title ) const;
 	const char get_first_letter( const FeRomInfo *one );
 
 	static void init_title_rex( const std::string & );

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -419,11 +419,12 @@ void FeSettings::load()
 	internal_load_language( load_language );
 
 	//
-	// Initialize the regular expression used when sorting by title now...
+	// Initialize the regular expression used when sorting by title
+	// - Previously this regex string resided in an external language file
+	// - Users tend to forget external files when updating, which would break the caller
+	// - So this regex is now HARD-CODED
 	//
-	std::string rex_str;
-	get_translation( "_sort_regexp", rex_str );
-	FeRomListSorter::init_title_rex( rex_str );
+	FeRomListSorter::init_title_rex( "^(?:Vs\\.\\s+)?(?:The\\s+)?(.*)$" );
 
 	load_state();
 
@@ -646,7 +647,7 @@ void FeSettings::load_layout_params()
 void FeSettings::init_display()
 {
 	FeLog() << std::endl << "*** Initializing display: '" << get_current_display_title() << "'" << std::endl;
-	
+
 	m_loaded_game_extras = false;
 
 	//
@@ -4188,10 +4189,10 @@ void FeSettings::update_romlist_after_edit(
 	UpdateType u_type )
 {
 	if ( m_current_display < 0 ) return;
-		
+
 	const std::string &romlist_name = m_displays[m_current_display].get_info(FeDisplayInfo::Romlist);
 	const std::string romlist_path = FE_ROMLIST_SUBDIR + romlist_name + FE_ROMLIST_FILE_EXTENSION;
-	
+
 	std::string in_path = m_config_path + romlist_path;
 	std::string out_path = in_path; // Out path is always in romlist directory
 
@@ -4203,11 +4204,11 @@ void FeSettings::update_romlist_after_edit(
 		std::string temp = FE_DATA_PATH + romlist_path;
 		if ( file_exists( temp ) ) in_path = temp;
 	}
-	
+
 	// Exit early if cannot open infile (do not even update in-memory romlist)
 	nowide::ifstream infile( in_path.c_str() );
 	if ( !infile.is_open() ) return;
-	
+
 	//
 	// Update the in-memory romlist now
 	//
@@ -4326,7 +4327,7 @@ void FeSettings::update_romlist_after_edit(
 
 		delete_file( path );
 	}
-	
+
 	// Finally, re-create filters *after* romlist file has been updated
 	// RomInfo operator== compares romname and emulator
 	if ( ( u_type == EraseEntry ) || (( u_type == UpdateEntry ) && !( original == replacement )) )

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -223,18 +223,20 @@ int icompare(
 	const std::string &one,
 	const std::string &two )
 {
-	unsigned int one_len = one.size();
+	int s1 = one.size();
+	int s2 = two.size();
+	int size = std::min( s1, s2 );
+	int c1, c2;
 
-	if ( one_len != two.size() )
-		return ( one_len - two.size() );
-
-	for ( unsigned int i=0; i < one_len; i++ )
+	for ( int i = 0; i < size; i++ )
 	{
-		if ( std::tolower( one[i] ) != std::tolower( two[i] ) )
-			return ( one[i] - two[i] );
+		c1 = std::tolower( one[i] );
+		c2 = std::tolower( two[i] );
+		if ( c1 != c2 )
+			return std::clamp( c1 - c2, -1, 1 );
 	}
 
-	return 0;
+	return std::clamp( s1 - s2, -1, 1 );
 }
 
 bool base_compare( const std::string &path,
@@ -855,12 +857,11 @@ int as_int( const std::string &s )
 	return atoi( s.c_str() );
 }
 
-bool config_str_to_bool( const std::string &s )
+bool config_str_to_bool( const std::string &s, bool permissive )
 {
-	if (( s.compare( "yes" ) == 0 ) || ( s.compare( "true" ) == 0 ))
-		return true;
-	else
-		return false;
+	return permissive
+		? !(( s.compare( "no" ) == 0 ) || ( s.compare( "false" ) == 0 ))
+		: (( s.compare( "yes" ) == 0 ) || ( s.compare( "true" ) == 0 ));
 }
 
 const char *get_OS_string()

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -80,7 +80,7 @@ bool tail_compare(
 
 //
 // Case insensitive compare of one and two
-// returns 0 if equal
+// - Returns -1 if one < two, 1 if one > two, 0 if equal
 //
 int icompare( const std::string &one,
 	const std::string &two );
@@ -289,9 +289,11 @@ std::string as_str( float f, int decimals=3 );
 int as_int( const std::string &s );
 
 //
-// Return config string (i.e. "yes", "true", "no", "false" as bool
+// Return bool representing given string
+// - "yes" or "true" = true, anything else = false
+// - If permissive "no" or "false" = false, anything else = true
 //
-bool config_str_to_bool( const std::string &s );
+bool config_str_to_bool( const std::string &s, bool permissive = false );
 
 //
 // Return the name of the operating system.

--- a/src/fe_util_sq.cpp
+++ b/src/fe_util_sq.cpp
@@ -24,6 +24,26 @@
 #include "fe_util.hpp" // perform_substitution
 #include <sqrat.h>
 
+// Convert SQChar to std::string
+std::string scstdstr( const SQChar* s )
+{
+#ifdef SQUNICODE
+	return FeUtil::narrow( s );
+#else
+	return std::string( s );
+#endif
+}
+
+// Convert std::string to SQChar
+const SQChar *scsqchar( std::string s )
+{
+#ifdef SQUNICODE
+	return FeUtil::widen( s ).c_str();
+#else
+	return s.c_str();
+#endif
+}
+
 bool fe_get_object_string(
 	HSQUIRRELVM vm,
 	const HSQOBJECT &obj,
@@ -35,7 +55,7 @@ bool fe_get_object_string(
 	SQRESULT res = sq_getstring(vm, -1, &s);
 	bool r = SQ_SUCCEEDED(res);
 	if (r)
-		out_string = s;
+		out_string = scstdstr( s );
 
 	sq_pop(vm,2);
 	return r;
@@ -53,7 +73,7 @@ bool fe_get_attribute_string(
 	if ( key.empty() )
 		sq_pushnull(vm);
 	else
-		sq_pushstring(vm, key.c_str(), key.size());
+		sq_pushstring(vm, scsqchar( key ), key.size() );
 
 	if ( SQ_FAILED( sq_getattributes(vm, -2) ) )
 	{
@@ -71,7 +91,7 @@ bool fe_get_attribute_string(
 	if ( attTable.IsNull() )
 		return false;
 
-	Sqrat::Object attVal = attTable.GetSlot( attribute.c_str() );
+	Sqrat::Object attVal = attTable.GetSlot( scsqchar( attribute ) );
 	if ( attVal.IsNull() )
 		return false;
 
@@ -139,7 +159,7 @@ void fe_register_global_func(
 	const char *name )
 {
         sq_pushroottable( vm );
-        sq_pushstring( vm, name, -1 );
+        sq_pushstring( vm, scsqchar( name ), -1 );
         sq_newclosure( vm, f, 0 );
         sq_newslot( vm, -3, SQFalse );
         sq_pop( vm, 1 ); // pops the root table

--- a/src/fe_util_sq.hpp
+++ b/src/fe_util_sq.hpp
@@ -29,6 +29,11 @@
 //
 // Squirrel utility functions.
 //
+
+std::string scstdstr( const SQChar* s );
+
+const SQChar *scsqchar( std::string s );
+
 bool fe_get_object_string(
 	HSQUIRRELVM vm,
 	const HSQOBJECT &obj,


### PR DESCRIPTION
- Update romlist title sort to use regex groups
- Update sort to allow reverse of any sort
- Update letter navigation to be case insensitive
- Update icompare to behave like std::string compare
- Update str_to_bool to allow permissive matching
- Add SQChar <-> std::string methods and replace inline conversions

`reverse_order true` is automatically added to `attract.cfg` when sorting by PlayedCount or PlayedTime
While there is no UI for it, the app will now respect `reverse_order` for *any* sort field
Following the Title sorting method, *all* fields are now case-insensitive

(Don't forget to copy the language folder over for the updated title sort rule)