### PR TITLE
Fix intro crash

### DIFF
--- a/src/fe_vm.hpp
+++ b/src/fe_vm.hpp
@@ -118,6 +118,7 @@ public:
 
 	void flag_redraw() { m_redraw_triggered = true; };
 	void flag_sort_zorder() { m_sort_zorder_triggered = true; };
+	void clear_commands();
 	void post_command( FeInputMap::Command c );
 	bool poll_command( FeInputMap::Command &c, std::optional<sf::Event> &ev, bool &from_ui );
 	void clear(); // override of base class clear()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -550,7 +550,14 @@ int main(int argc, char *argv[])
 				move_state = FeInputMap::LAST_COMMAND;
 				move_triggered = FeInputMap::LAST_COMMAND;
 				move_last_triggered = 0;
+				first_intro = false;
+				redraw = true;
+				c = FeInputMap::LAST_COMMAND;
 				bool has_layout = false;
+
+				// Clear any commands the intro may have queued up
+				// - Fixes intro "select" error
+				feVM.clear_commands();
 
 				if ( first_intro && mode == FeSettings::LaunchLastGame )
 				{
@@ -562,9 +569,9 @@ int main(int argc, char *argv[])
 
 				if ( mode == FeSettings::ShowDisplaysMenu )
 				{
-					// If there is a custom displays_menu clear the state so it loads on cb_signal
+					// Update command to show DisplaysMenu in the current loop
 					has_layout = feSettings.has_custom_displays_menu();
-					if ( has_layout ) feSettings.set_present_state( FeSettings::Layout_Showing );
+					c = FeInputMap::DisplaysMenu;
 				}
 
 				if ( !has_layout )
@@ -573,12 +580,7 @@ int main(int argc, char *argv[])
 					feVM.load_layout( true );
 				}
 
-				if ( mode == FeSettings::ShowDisplaysMenu )
-					FeVM::cb_signal( "displays_menu" );
-
-				first_intro = false;
-				redraw = true;
-				continue;
+				if ( c == FeInputMap::LAST_COMMAND ) continue;
 			}
 
 			//


### PR DESCRIPTION
How to reproduce:
- Intro: Enabled
- Videos: Ensure they're all missing
- Startup: DisplaysMenu with Custom Layout

Result:
- `intro.nut` fires `fe.signal("select")` 2 times from `intro_tick -> exit()`
  - `select` command is queued 2 times in `post_command`
- `poll_command` processes the first `select`
  - `Intro_Showing` block captures the `select`
  - clears the `Intro_Showing` state
  - queues `displays_menu` command
- `poll_command` processes the second `select`
  - Since `Intro_Showing` was cleared it no longer captures the `select`
  - `select` now attempts to `launch`, causing an error

Regression caused by https://github.com/oomek/attractplus/pull/151
`Intro_Showing` block previously captured the extra `select` - but effectively loaded the layout multiple times
Fixed by clearing queued commands in the `Intro_Showing` block