### PR TITLE
Add Config Helpers

### DIFF
--- a/src/fe_config.hpp
+++ b/src/fe_config.hpp
@@ -43,11 +43,15 @@ namespace Opt
 	const int	LIST        = 2; // option gets selected from values_list
 	const int	INFO        = 3; // option is just for info (no changes)
 	const int	MENU        = 4; // option leads to another menu
-	const int	SUBMENU     = 5; // option leads to submenu of current menu
-	const int	RELOAD      = 6; // option reloads menu
-	const int	EXIT        = 7; // option results in exiting the menu
-	const int	DEFAULTEXIT = 8; // option is default for exiting the menu
-	const int	TOGGLE      = 9; // option is a toggle (yes/no)
+	const int	RELOAD      = 5; // option reloads menu
+	const int	EXIT        = 6; // option results in exiting the menu
+	const int	DEFAULTEXIT = 7; // option is default for exiting the menu
+	const int	TOGGLE      = 8; // option is a toggle (yes/no)
+};
+
+namespace OptFlag {
+	const int TRANSLATE_NONE	= 1 << 0; // do no translate label
+	const int TRANSLATE_LABEL	= 1 << 1; // translate the label
 };
 
 //
@@ -87,6 +91,7 @@ public:
 
 	const std::string &get_value() const;
 	int get_vindex() const;
+	const char* get_bool();
 
 	void append_vlist( const char **clist );
 	void append_vlist( const std::vector< std::string > &list );
@@ -105,8 +110,8 @@ private:
 public:
 	enum Style
 	{
-		SelectionList,
-		EditList
+		SelectionList,	// A single list
+		EditList		// A split option/value list
 	};
 
 	FeSettings &fe_settings;
@@ -121,24 +126,34 @@ public:
 
 	FeConfigContext( FeSettings & );
 
-	//
-	// Convenient addition of menu options
-	//
-	// set and val are added without language lookup.  help gets lookup.
-	void add_opt( int type, const std::string &set,
-		const std::string &val="", const std::string &help="" );
 
-	// set and help get language lookup
-	void add_optl( int type, const std::string &set,
-		const std::string &val="", const std::string &help="" );
+	// Add menu option. Help always gets translated.
+	FeMenuOpt *add_opt(
+		const int type,
+		const std::string &label,
+		const std::string &value,
+		const std::string &help="",
+		const int &opaque=0,
+		const int &flags=OptFlag::TRANSLATE_LABEL
+	);
+
+	// Add menu toggle option.
+	FeMenuOpt *add_opt(
+		const int type,
+		const std::string &label,
+		const bool &value,
+		const std::string &help="",
+		const int &opaque=0,
+		const int &flags=OptFlag::TRANSLATE_LABEL
+	);
 
 	// set the Style and title for the menu.
 	void set_style( Style s, const std::string &t );
 
-	//
-	// Convenient access
-	//
+	// Return curr_sel option
 	FeMenuOpt &curr_opt() { return opt_list[curr_sel]; }
+
+	// Return last option in opt_list; }
 	FeMenuOpt &back_opt() { return opt_list.back(); }
 
 	//

--- a/src/fe_listbox.cpp
+++ b/src/fe_listbox.cpp
@@ -197,7 +197,7 @@ void FeListBox::setColor( sf::Color c )
 
 	m_base_text.setColor( c );
 
-	for ( int i=0; i < m_texts.size(); i++ )
+	for ( int i=0; i < (int)m_texts.size(); i++ )
 		if ( i != m_selected_row )
 			m_texts[i].setColor( c );
 
@@ -253,7 +253,7 @@ void FeListBox::setTextScale( const sf::Vector2f &scale )
 {
 	m_base_text.setTextScale( scale );
 
-	for ( unsigned int i=0; i < m_texts.size(); i++ )
+	for ( int i=0; i < (int)m_texts.size(); i++ )
 		m_texts[i].setTextScale( scale );
 }
 
@@ -409,7 +409,7 @@ void FeListBox::setRotation( float r )
 
 	m_rotation = r;
 
-	for ( unsigned int i=0; i < m_texts.size(); i++ )
+	for ( int i=0; i < (int)m_texts.size(); i++ )
 		m_texts[i].setRotation( m_rotation );
 
 	if ( m_scripted )
@@ -581,7 +581,7 @@ void FeListBox::setBgColor( sf::Color c )
 		return;
 
 	m_base_text.setBgColor(c);
-	for ( int i=0; i < m_texts.size(); i++ )
+	for ( int i=0; i < (int)m_texts.size(); i++ )
 		if ( i != m_selected_row )
 			m_texts[i].setBgColor( c );
 
@@ -663,7 +663,7 @@ void FeListBox::set_style(int s)
 		return;
 
 	m_base_text.setStyle(s);
-	for ( int i=0; i < m_texts.size(); i++ )
+	for ( int i=0; i < (int)m_texts.size(); i++ )
 		if ( i != m_selected_row )
 			m_texts[i].setStyle( s );
 
@@ -678,7 +678,7 @@ void FeListBox::set_align(int a)
 
 	m_base_text.setAlignment( (FeTextPrimitive::Alignment)a);
 
-	for ( unsigned int i=0; i < m_texts.size(); i++ )
+	for ( int i=0; i < (int)m_texts.size(); i++ )
 		m_texts[i].setAlignment( (FeTextPrimitive::Alignment)a );
 
 	if ( m_scripted )

--- a/src/fe_overlay.hpp
+++ b/src/fe_overlay.hpp
@@ -207,7 +207,9 @@ public:
 	void init();
 	void style_init();
 	void style_init( sf::Color theme_color );
-	void swap_yes_no_to_pill_glyphs( FeSettings &settings, std::vector< std::string > &right_list, const std::vector< FeMenuOpt > &opt_list, int idx );
+
+	const bool is_yes_no_list( const std::vector<std::string> &values ) const;
+	void swap_yes_no_to_pill_glyphs( std::vector<std::string> &right_list, const std::vector<FeMenuOpt> &opt_list, int idx );
 };
 
 #endif

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -3529,18 +3529,60 @@ void FeSettings::save() const
 	}
 }
 
-void FeSettings::get_translation( const std::string &token, std::string &str ) const
+// Populate str with char translation
+const void FeSettings::get_translation( const char* &token, std::string &str ) const
+{
+	if ( token ) m_translation_map.get_translation( token, str );
+}
+
+// Populate str with string translation
+const void FeSettings::get_translation( const std::string &token, std::string &str ) const
 {
 	m_translation_map.get_translation( token, str );
 }
 
-void FeSettings::get_translation( const std::string &token,
-					const std::string &rep, std::string &str ) const
+// Return translated char, if null returns empty string
+const std::string FeSettings::get_translation( const char* value ) const
 {
-	m_translation_map.get_translation( token, str );
+	std::string t;
+	if ( value ) get_translation( value, t );
+	return t;
+}
 
-	if ( !rep.empty() )
-		perform_substitution( str, "$1", rep );
+// Return translated string
+const std::string FeSettings::get_translation( const std::string &value ) const
+{
+	std::string t;
+	get_translation( value, t );
+	return t;
+}
+
+// Return translated array of chars, omits null tokens
+const std::vector<std::string> FeSettings::get_translation( const char* tokens[] ) const
+{
+    int n = 0;
+	while ( tokens[n] != 0 ) n++;
+	std::vector<std::string> ret;
+	ret.reserve( n );
+	for ( int i=0; i<n; i++ )
+	{
+		ret.push_back( std::string() );
+		get_translation( tokens[i], ret.back() );
+	}
+	return ret;
+}
+
+// Return translated array of strings
+const std::vector<std::string> FeSettings::get_translation( const std::vector<std::string> &tokens ) const
+{
+	std::vector<std::string> ret;
+	ret.reserve( tokens.size() );
+	for ( std::vector<std::string>::const_iterator it=tokens.begin(); it!=tokens.end(); ++it)
+	{
+		ret.push_back( std::string() );
+		get_translation( *it, ret.back() );
+	}
+	return ret;
 }
 
 int FeSettings::displays_count() const

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -626,9 +626,12 @@ public:
 
 	void save() const;
 
-	void get_translation( const std::string &token, std::string &str ) const;
-	void get_translation( const std::string &token, const std::string &rep,
-		std::string &str ) const;
+	const void get_translation( const char* &token, std::string &str ) const;
+	const void get_translation( const std::string &token, std::string &str ) const;
+	const std::string get_translation( const char* value ) const;
+	const std::string get_translation( const std::string &value ) const;
+	const std::vector<std::string> get_translation( const char* tokens[] ) const;
+	const std::vector<std::string> get_translation( const std::vector<std::string> &tokens ) const;
 
 	void set_language( const std::string &l );
 	void get_languages_list( std::vector < FeLanguage > &ll ) const;

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -757,22 +757,39 @@ bool token_helper( const std::string &from,
 	return retval;
 }
 
-int perform_substitution( std::string &target,
-					const std::string &from,
-					const std::string &to )
+int perform_substitution(
+	std::string &target,
+	const std::string &from,
+	const std::string &to
+)
 {
-	int count=0;
+	int count = 0;
 
 	if ( from.empty() )
 		return count;
 
-	size_t loc=0;
+	size_t loc = 0;
+	size_t from_size = from.size();
+	size_t to_size = to.size();
+
 	while ( (loc = target.find( from, loc )) != std::string::npos )
 	{
-		target.replace( loc, from.size(), to );
-		loc += to.size();
+		target.replace( loc, from_size, to );
+		loc += to_size;
 		count++;
 	}
+
+	return count;
+}
+
+int perform_substitution(
+	std::string &target,
+	const std::vector<std::string> &rep
+)
+{
+	int count = 0;
+	for ( int i=rep.size()-1; i>=0; i-- )
+		count += perform_substitution( target, "$" + as_str( i+1 ), rep[i] );
 
 	return count;
 }
@@ -839,9 +856,12 @@ bool confirm_directory( const std::string &base, const std::string &sub )
 
 std::string as_str( int i )
 {
-	std::ostringstream ss;
-	ss << i;
-	return ss.str();
+	return std::to_string( i );
+}
+
+std::string as_str( size_t t )
+{
+	return std::to_string( t );
 }
 
 std::string as_str( float f, int decimals )
@@ -850,7 +870,6 @@ std::string as_str( float f, int decimals )
 	ss << std::setprecision( decimals ) << std::fixed << f;
 	return ss.str();
 }
-
 
 int as_int( const std::string &s )
 {

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -50,14 +50,22 @@ bool token_helper( const std::string &from,
 	size_t &pos, std::string &token, const char *sep=";" );
 
 //
-// Substitute all occurrences of "from" that appear in "target" with
-// the text from "to"
+// Substitute all occurrences of "from" that appear in "target" with the text from "to"
+// - Returns the number of substitutions made
 //
-// returns the number of substitutions made
-//
-int perform_substitution( std::string &target,
+int perform_substitution(
+	std::string &target,
 	const std::string &from,
-	const std::string &to );
+	const std::string &to
+);
+
+//
+// Substitute placeholders in target with values in list, $1 = rep[0], etc
+//
+int perform_substitution(
+	std::string &target,
+	const std::vector<std::string> &rep
+);
 
 //
 //
@@ -277,6 +285,11 @@ void delete_file( const std::string &file );
 // Return integer as a string
 //
 std::string as_str( int i );
+
+//
+// Return size_t as a string
+//
+std::string as_str( size_t t );
 
 //
 // Return float as a string

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1971,7 +1971,7 @@ void FeVM::script_get_config_options(
 				else if ( is_func )
 				{
 					itx = my_opts.insert(
-						std::pair<int, FeMenuOpt>( order, FeMenuOpt(Opt::SUBMENU, label, "", help, 2, value ) )
+						std::pair<int, FeMenuOpt>( order, FeMenuOpt(Opt::MENU, label, "", help, 2, value ) )
 					);
 				}
 				else if ( is_info )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
 
 		if ( !exit_selected )
 		{
-			if ( feOverlay.confirm_dialog( "Auto-detect emulators?", "" ) == 0 )
+			if ( feOverlay.confirm_dialog( "Auto-detect emulators?" ) == 0 )
 			{
 				FeLog() << "Performing emulator auto-detection" << std::endl;
 				feVM.setup_wizard();

--- a/src/scraper_gamesdb.cpp
+++ b/src/scraper_gamesdb.cpp
@@ -322,7 +322,7 @@ bool get_json_doc( const std::string &api_key, rapidjson::Document &doc, const c
 {
 	std::string my_url = HOSTNAME;
 	my_url += req;
-	perform_substitution( my_url, "$1", api_key );
+	perform_substitution( my_url, { api_key } );
 
 	FeNetTask my_task( my_url, 0 );
 	my_task.do_task();
@@ -670,8 +670,7 @@ void create_single_id_query(
 		id = IMAGE_QUERY;
 	}
 
-	perform_substitution( my_req, "$1", api_key );
-	perform_substitution( my_req, "$2", id_str );
+	perform_substitution( my_req, { api_key, id_str } );
 
 	FeDebug() << " - db query: " << my_req << std::endl;
 	q.add_buffer_task( my_req, id );
@@ -773,8 +772,7 @@ bool FeSettings::thegamesdb_scraper( FeImporterContext &c )
 		// Get emulator specific images
 		std::string my_req = HOSTNAME;
 		my_req += "/Platforms/Images?apikey=$1&platforms_id=$2";
-		perform_substitution( my_req, "$1", api_key );
-		perform_substitution( my_req, "$2", as_str( plats[0].second ) );
+		perform_substitution( my_req, { api_key, as_str( plats[0].second ) } );
 
 		FeNetTask my_task( my_req, 0 );
 		if ( !my_task.do_task() )
@@ -863,9 +861,11 @@ fail_emu_scrape:
 
 		std::string my_req = HOSTNAME;
 		my_req += "/Games/ByGameName?apikey=$1&name=$2&fields=players%2Cpublishers%2Cgenres%2Coverview&filter%5Bplatform%5D=$3";
-		perform_substitution( my_req, "$1", api_key );
-		perform_substitution( my_req, "$2", url_escape( name_with_brackets_stripped( temp ) ) );
-		perform_substitution( my_req, "$3", plat_id_str );
+		perform_substitution( my_req, {
+			api_key,
+			url_escape( name_with_brackets_stripped( temp ) ),
+			plat_id_str
+		});
 
 		my_fuzz_map[ get_fuzzy( temp ) ] = name_worklist.back();
 		name_worklist.pop_back();

--- a/src/scraper_general.cpp
+++ b/src/scraper_general.cpp
@@ -863,8 +863,10 @@ bool FeSettings::build_romlist( const std::vector<std::string> &emu_list, const 
 	write_romlist( filename, total_romlist );
 
 	if ( user_message.empty() )
-		get_translation( "Wrote $1 entries to Collection/Rom List",
-			as_str( (int)total_romlist.size() ), msg );
+	{
+		get_translation( "Wrote $1 entries to Collection/Rom List", msg );
+		perform_substitution( msg, { as_str( total_romlist.size() ) });
+	}
 	else
 		msg = user_message;
 
@@ -929,7 +931,10 @@ bool FeSettings::scrape_artwork( const std::string &emu_name, UiUpdate uiu, void
 	FeLog() << "*** Scraping done." << std::endl;
 
 	if ( ctx.user_message.empty() )
-		get_translation( "Scraped $1 artwork file(s)", as_str( ctx.download_count ), msg );
+	{
+		get_translation( "Scraped $1 artwork file(s)", msg );
+		perform_substitution( msg, { as_str( ctx.download_count ) });
+	}
 	else
 		msg = ctx.user_message;
 


### PR DESCRIPTION
- Add `get_translation` overloads to return strings, as well as translate lists for `Opt::LIST` values
- Remove `rep` arg from `get_translation`, must now call `perform_substitution` afterward
- Remove `Opt::SUBMENU` since it's identical to `Opt::MENU`
- Combine `add_opt` and `add_optl`, now use `flags` to specify `TRANSLATE_NONE` for rare cases
- Add `Opt::TOGGLE` detection to `add_opt` for easy yes/no creation
- Add `perform_subsitution` support for multiple replacements
- Reduce `fe_config.cpp`, by ~500 lines
- Clean up build warnings

No new features, just some refactoring to help DRY `fe_config` a little.
To test ensure the config menu does not crash anywhere.