### PR TITLE
Fix Listbox Custom Text Again

### DIFF
--- a/src/fe_listbox.cpp
+++ b/src/fe_listbox.cpp
@@ -273,12 +273,10 @@ void FeListBox::setCustomSelection( const int index )
 	internalSetText( index );
 }
 
-void FeListBox::setCustomText( const int index,
-			const std::vector<std::string> &list )
+void FeListBox::setCustomText( const int index, const std::vector<std::string> &list )
 {
-	m_custom_sel = list.empty() ? -1 : index;
 	m_custom_list = list;
-	internalSetText( m_custom_sel );
+	setCustomSelection( list.empty() ? -1 : index );
 }
 
 void FeListBox::internalSetText( const int index )
@@ -365,20 +363,18 @@ void FeListBox::internalSetText( const int index )
 			break;
 	}
 
+	bool use_custom_list = has_custom_list();
 	std::string text_string;
-	std::string format_string;
-
-	if ( m_scripted )
-		format_string = m_format_string.empty()
-			? DEFAULT_FORMAT_STRING
-			: m_format_string;
+	std::string format_string = m_format_string.empty()
+		? DEFAULT_FORMAT_STRING
+		: m_format_string;
 
 	for ( int i=0; i < display_rows; i++ )
 	{
 		int listentry = i + offset;
 		if ( listentry < 0 || listentry >= list_size )
 			text_string = "";
-		else if ( has_custom_list() )
+		else if ( use_custom_list )
 			text_string = m_custom_list[ listentry ];
 		else
 		{

--- a/src/fe_listbox.hpp
+++ b/src/fe_listbox.hpp
@@ -192,13 +192,10 @@ private:
 	int m_display_rom_index;
 	FeSettings *m_feSettings;
 
-	// this contains the custom selection index, if custom text has been
-	// set (in which case m_displayList contains the custom set text). If
-	// no custom text is set, then this is set to -1, and the control gets
-	// automagically updated with game info whenever the selection
-	// changes, etc
+	// Contains the selection index of m_custom_list, if the list is not empty.
+	// Otherwise the control gets automagically updated with game info whenever the selection changes.
 	int m_custom_sel;
-	bool has_custom_list() { return m_custom_sel != -1; }
+	bool has_custom_list() { return m_custom_list.size() > 0; }
 
 	void draw( sf::RenderTarget &target, sf::RenderStates states ) const;
 };


### PR DESCRIPTION
- Overlay is setting custom list selection to -1 for new filter rules, causing `has_custom_list` to incorrectly return `false`.
- Updated `has_custom_list` to check `m_custom_list` size instead.

New Filter Rule Target and Comparison value lists now draw properly again.