### PR TITLE
Refactor Romlist and Cache handlers

### DIFF
--- a/src/fe_base.cpp
+++ b/src/fe_base.cpp
@@ -34,14 +34,13 @@ extern "C"
 #include "nowide/fstream.hpp"
 #include "nowide/iostream.hpp"
 
-#define FE_NAME_D			"Attract-Mode Plus"
+#define FE_NAME_D           "Attract-Mode Plus"
+#define FE_AUTHOR_D         "Copyright © 2013-2025 Andrew Mickelson & Radek Dutkiewicz"
 
 const char *FE_NAME         = FE_NAME_D;
-const char *FE_COPYRIGHT    = FE_NAME_D " " FE_VERSION_D " " FE_BUILD_D "\n" \
-	"Copyright © 2013-2025 Andrew Mickelson & Radek Dutkiewicz";
+const char *FE_COPYRIGHT    = FE_NAME_D " " FE_VERSION_D " " FE_BUILD_D "\n" FE_AUTHOR_D;
 const char *FE_VERSION      = FE_VERSION_D;
-
-const char *FE_BUILD_NUMBER  = FE_BUILD_D;
+const char *FE_BUILD_NUMBER = FE_BUILD_D;
 
 const char *FE_WHITESPACE   = " \t\r";
 const char *FE_DIR_TOKEN    = "<DIR>";
@@ -52,6 +51,8 @@ const char *FE_EMULATOR_SUBDIR           = "emulators/";
 const char *FE_EMULATOR_TEMPLATES_SUBDIR = "emulators/templates/";
 const char *FE_EMULATOR_FILE_EXTENSION   = ".cfg";
 const char *FE_EMULATOR_DEFAULT          = "default-emulator.cfg";
+
+const std::uint32_t FE_CACHE_VERSION = std::hash<std::string>{}( std::string( FE_VERSION ) + FE_BUILD_NUMBER );
 
 namespace {
 	nowide::ofstream g_logfile;

--- a/src/fe_base.hpp
+++ b/src/fe_base.hpp
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <ostream>
+#include <cstdint>
 
 extern const char *FE_NAME;
 extern const char *FE_COPYRIGHT;
@@ -37,6 +38,8 @@ extern const char *FE_EMULATOR_SUBDIR;
 extern const char *FE_EMULATOR_TEMPLATES_SUBDIR;
 extern const char *FE_EMULATOR_FILE_EXTENSION;
 extern const char *FE_EMULATOR_DEFAULT;
+
+extern const std::uint32_t FE_CACHE_VERSION;
 
 enum FeLogLevel
 {

--- a/src/fe_cache.cpp
+++ b/src/fe_cache.cpp
@@ -1,11 +1,59 @@
 #include "fe_cache.hpp"
 
-// Enable the romlist cache - removing will revert to previous "on-demand" romlist behaviour
+// Enable the romlist cache
+// - disabling prevents all caching
 #define FE_CACHE_ENABLE
 
-// Save cache as binary files, which are smaller and faster than JSON, but not readable
+// Enable cache debug logging
+// - outputs using FeLog
+// #define FE_CACHE_DEBUG
+
+// Save cache as binary files
+// - smaller and faster than JSON, but not easily readable
 #define FE_CACHE_BINARY
 
+// -------------------------------------------------------------------------------------
+
+/*
+	Events that invalidate the cache:
+
+	- Configure
+		- Display > Global Filter (invalidate_display)
+		- Display > Filter (invalidate_filter)
+		- General > Group Clones (invalidate_display)
+	- GUI Edit
+		- Edit Rom Info (invalidate_romlistmeta)
+		- Add / Remove Tag (invalidate_rominfo)
+		- Add / Remove Fav (invalidate_rominfo)
+	- Modifying files
+		- Romlist (invalidate_romlistmeta)
+		- Tags (invalidate_display)
+		- Fav (invalidate_display)
+		- Roms (invalidate_available)
+
+	NOTE:
+	- FileIsAvailable must be used by a display for modified roms to invalidate its cache
+	- Tag/Fav must be used by a display for Add/Remove to invalidate its cache
+	- On first run all the debug info will report "Failed", this is normal since there's no cache
+
+	Invalidations may cause a cascade of cache deletions!
+	For example, modifying the romlist will invalidate RomlistMeta, triggering invalidation of ALL displays using that romlist
+
+		invalidate_romlistmeta	-> invalidate_romlist
+		invalidate_romlist		-> invalidate_display
+		invalidate_display		-> invalidate_globalfilter
+		invalidate_globalfilter	-> invalidate_filter
+		invalidate_filter
+		invalidate_available	-> invalidate_rominfo
+		invalidate_rominfo		-> invalidate_globalfilter | invalidate_filter
+		invalidate_stats		-> invalidate_rominfo (called prior)
+
+		validate_romlistmeta 	-> invalidate_romlistmeta
+		validate_display 		-> invalidate_display
+		validate_available 		-> invalidate_available
+*/
+
+// Include depending on the cache mode
 #ifdef FE_CACHE_BINARY
 #include <cereal/archives/binary.hpp>
 typedef cereal::BinaryOutputArchive OutputArchive;
@@ -22,16 +70,77 @@ const char *FE_CACHE_SUBDIR = "cache/";
 const char *FE_CACHE_STATS = "stats";
 const char *FE_CACHE_FILTER = "filter";
 const char *FE_CACHE_DISPLAY = "display";
-const char *FE_CACHE_ROMHASH = "romhash";
+const char *FE_CACHE_EMULATOR = "emulator";
+const char *FE_CACHE_AVAILABLE = "available";
 const char *FE_CACHE_ROMLIST = "romlist";
+const char *FE_CACHE_CONFIG = "config";
 const char *FE_CACHE_GLOBALFILTER = "globalfilter";
 const std::string FE_EMPTY_STRING;
 
 std::vector<FeDisplayInfo>* FeCache::m_displays = {};
 std::string FeCache::m_config_path = "";
+std::map<std::string, std::map<std::string, std::vector<std::string>>> FeCache::m_stats_cache = {};
+int FeCache::m_indent = 0;
 
-// Global storage for [emulator][romname] stats
-std::map<std::string, FeListStats> FeCache::stats_cache = std::map<std::string, FeListStats>{};
+// -------------------------------------------------------------------------------------
+
+#ifdef FE_CACHE_DEBUG
+
+//
+// Debug logging with indentation
+// - Invalidation methods often trigger each other, this makes it easier to find the root
+//
+void FeCache::debug(
+	std::string value,
+	std::string filename,
+	bool success
+)
+{
+	FeLog() << "FeCache: "
+		<< std::string( 2 * m_indent++, ' ')
+		<< value
+		<< ( !filename.empty() ? " '" + filename + "'" : "" )
+		<< ( !success ? " Failed" : "" )
+		<< std::endl;
+}
+
+void FeCache::_debug()
+{
+	m_indent--;
+}
+
+#else
+
+void FeCache::debug( std::string value, std::string filename, bool success ) {}
+void FeCache::_debug() {}
+
+#endif
+
+// -------------------------------------------------------------------------------------
+
+#ifndef FE_CACHE_ENABLE
+
+// Dummy methods if cache is disabled
+void FeCache::set_config_path( const std::string path ) {}
+void FeCache::set_displays( std::vector<FeDisplayInfo>* displays ) {}
+bool FeCache::validate_romlistmeta( FeRomList &romlist ) { return false; }
+bool FeCache::save_display( FeDisplayInfo &display, FeRomList &romlist ) { return false; }
+bool FeCache::validate_display( FeDisplayInfo &display, FeRomList &romlist ) { return false; }
+bool FeCache::save_available( const FeRomList &romlist, const std::map<std::string, std::vector<std::string>> &emu_roms ) { return false; }
+bool FeCache::load_available( const FeRomList &romlist, std::map<std::string, std::vector<std::string>> &emu_roms ) { return false; }
+bool FeCache::validate_available( FeRomList &romlist, std::map<std::string, std::vector<std::string>> &emu_roms ) { return false; }
+bool FeCache::save_romlist( const FeRomList &romlist ) { return false; }
+bool FeCache::load_romlist( FeRomList &romlist ) { return false; }
+bool FeCache::save_globalfilter( const FeDisplayInfo &display, const FeRomList &romlist ) { return false; }
+bool FeCache::load_globalfilter( const FeDisplayInfo &display, FeRomList &romlist ) { return false; }
+bool FeCache::save_filter( FeDisplayInfo &display, const FeFilterEntry &entry, const int filter_index ) { return false; }
+bool FeCache::load_filter( FeDisplayInfo &display, FeFilterEntry &entry, const int filter_index, const std::map<int, FeRomInfo*> &lookup ) { return false; }
+void FeCache::invalidate_rominfo( const FeRomList &romlist, const std::set<FeRomInfo::Index> targets ) {}
+void FeCache::clear_stats() {}
+bool FeCache::set_stats_info( const std::string &path, const std::vector<std::string> &rominfo ) { return false; }
+bool FeCache::get_stats_info( const std::string &path, std::vector<std::string> &rominfo ) { return false; }
+
+#else
 
 // -------------------------------------------------------------------------------------
 
@@ -39,7 +148,7 @@ std::map<std::string, FeListStats> FeCache::stats_cache = std::map<std::string, 
 // Create path for config files
 //
 void FeCache::set_config_path(
-	std::string path
+	const std::string path
 )
 {
 	m_config_path = path;
@@ -58,639 +167,750 @@ void FeCache::set_displays(
 
 // -------------------------------------------------------------------------------------
 
-//
-// Returns sanitized filename for romhash cache
-//
-std::string FeCache::get_romhash_cache_filename(
-	const std::string &romlist_name
+std::string FeCache::get_romlistmeta_filename(
+	const FeRomList &romlist
 )
 {
-	if ( romlist_name.empty() ) return FE_EMPTY_STRING;
-	return m_config_path
-		+ FE_CACHE_SUBDIR
-		+ FE_CACHE_ROMHASH + "."
-		+ sanitize_filename( romlist_name )
-		+ FE_CACHE_EXT;
+	std::string name = romlist.get_romlist_name();
+	return name.empty()
+		? FE_EMPTY_STRING
+		: m_config_path + FE_CACHE_SUBDIR + FE_CACHE_ROMLIST + "." + sanitize_filename( name ) + "." + FE_CACHE_CONFIG + FE_CACHE_EXT;
 }
 
-//
-// Returns sanitized filename for romlist cache
-//
-std::string FeCache::get_romlist_cache_filename(
-	const std::string &romlist_name
-)
-{
-	if ( romlist_name.empty() ) return FE_EMPTY_STRING;
-	return m_config_path
-		+ FE_CACHE_SUBDIR
-		+ FE_CACHE_ROMLIST + "."
-		+ sanitize_filename( romlist_name )
-		+ FE_CACHE_EXT;
-}
-
-//
-// Returns sanitized filename for globalfilter cache
-//
-std::string FeCache::get_globalfilter_cache_filename(
-	FeDisplayInfo &display
+std::string FeCache::get_display_filename(
+	const FeDisplayInfo &display
 )
 {
 	std::string name = display.get_name();
-	if ( name.empty() ) return FE_EMPTY_STRING;
-	return m_config_path
-		+ FE_CACHE_SUBDIR
-		+ FE_CACHE_DISPLAY + "."
-		+ sanitize_filename( name ) + "."
-		+ FE_CACHE_GLOBALFILTER
-		+ FE_CACHE_EXT;
+	return name.empty()
+		? FE_EMPTY_STRING
+		: m_config_path + FE_CACHE_SUBDIR + FE_CACHE_DISPLAY + "." + sanitize_filename( name ) + "." + FE_CACHE_CONFIG + FE_CACHE_EXT;
 }
 
-//
-// Returns sanitized filename for filter cache
-//
-std::string FeCache::get_filter_cache_filename(
-	FeDisplayInfo &display,
-	int filter_index
+std::string FeCache::get_available_filename(
+	const FeRomList &romlist
+)
+{
+	std::string name = romlist.get_romlist_name();
+	return name.empty()
+		? FE_EMPTY_STRING
+		: m_config_path + FE_CACHE_SUBDIR + FE_CACHE_ROMLIST + "." + sanitize_filename( name ) + "." + FE_CACHE_AVAILABLE + FE_CACHE_EXT;
+}
+
+std::string FeCache::get_romlist_filename(
+	const FeRomList &romlist
+)
+{
+	std::string name = romlist.get_romlist_name();
+	return name.empty()
+		? FE_EMPTY_STRING
+		: m_config_path + FE_CACHE_SUBDIR + FE_CACHE_ROMLIST + "." + sanitize_filename( name ) + FE_CACHE_EXT;
+}
+
+std::string FeCache::get_globalfilter_filename(
+	const FeDisplayInfo &display
 )
 {
 	std::string name = display.get_name();
-	if ( name.empty() ) return FE_EMPTY_STRING;
-	return m_config_path
-		+ FE_CACHE_SUBDIR
-		+ FE_CACHE_DISPLAY + "."
-		+ sanitize_filename( name ) + "."
-		+ FE_CACHE_FILTER + "."
-		+ as_str( filter_index )
-		+ FE_CACHE_EXT;
+	return name.empty()
+		? FE_EMPTY_STRING
+		: m_config_path + FE_CACHE_SUBDIR + FE_CACHE_DISPLAY + "." + sanitize_filename( name ) + "." + FE_CACHE_GLOBALFILTER + FE_CACHE_EXT;
 }
 
-//
-// Returns sanitized filename for stat cache
-//
-std::string FeCache::get_stats_cache_filename(
-	std::string &emulator
+std::string FeCache::get_filter_filename(
+	const FeDisplayInfo &display,
+	const int filter_index
 )
 {
-	if ( emulator.empty() ) return FE_EMPTY_STRING;
-	return m_config_path
-		+ FE_CACHE_SUBDIR
-		+ FE_CACHE_STATS + "."
-		+ sanitize_filename( emulator )
-		+ FE_CACHE_EXT;
+	std::string name = display.get_name();
+	return name.empty()
+		? FE_EMPTY_STRING
+		: m_config_path + FE_CACHE_SUBDIR + FE_CACHE_DISPLAY + "." + sanitize_filename( name ) + "." + FE_CACHE_FILTER + "." + as_str( filter_index ) + FE_CACHE_EXT;
+}
+
+std::string FeCache::get_stats_filename(
+	const std::string &emulator
+)
+{
+	return emulator.empty()
+		? FE_EMPTY_STRING
+		: m_config_path + FE_CACHE_SUBDIR + FE_CACHE_EMULATOR + "." + sanitize_filename( emulator ) + "." + FE_CACHE_STATS + FE_CACHE_EXT;
 }
 
 // -------------------------------------------------------------------------------------
 
-//
-// Clears all cache using the given romlist (displays > globalfilters and filters)
-//
-void FeCache::invalidate_romlist(
-	const std::string &romlist_name
+template <typename T>
+bool FeCache::save_cache(
+	const std::string &filename,
+	const T &data
 )
 {
-#ifdef FE_CACHE_ENABLE
-	std::string filename = get_romhash_cache_filename( romlist_name );
-	if ( file_exists( filename ) ) delete_file( filename );
+	nowide::ofstream file( filename, std::ios::binary );
+	if ( !file.is_open() ) return false;
 
-	for (std::vector<FeDisplayInfo>::const_iterator itr=(*m_displays).begin(); itr!=(*m_displays).end(); ++itr)
+	try
 	{
-		FeDisplayInfo display = (*itr);
+		{	// block flushes archive
+			OutputArchive archive( file );
+			archive( data );
+		}
+		file.close();
+		return true;
+	}
+	catch (...)
+	{
+		file.close();
+		return false;
+	}
+}
+
+template <typename T>
+bool FeCache::load_cache(
+	const std::string &filename,
+	T &info
+)
+{
+	nowide::ifstream file( filename, std::ios::binary );
+	if ( !file.is_open() ) return false;
+
+	try
+	{
+		{	// block flushes archive
+			InputArchive archive( file );
+			archive( info );
+		}
+		file.close();
+		return true;
+	}
+	catch ( ... )
+	{
+		file.close();
+		return false;
+	}
+}
+
+void FeCache::delete_cache(
+	const std::string &filename
+)
+{
+	delete_file( filename );
+}
+
+// -------------------------------------------------------------------------------------
+//
+// RomlistMeta cache stores the modified time of the given romlist file
+// - Used to detect external changes to the romlist
+//
+
+bool FeCache::save_romlistmeta(
+	const FeRomList &romlist,
+	const std::map<std::string, std::string> &info
+)
+{
+	bool success = save_cache( get_romlistmeta_filename( romlist ), info );
+	debug( "Save RomlistMeta Cache", romlist.get_romlist_name(), success );
+	if ( !success ) invalidate_romlistmeta( romlist );
+	_debug();
+	return success;
+}
+
+bool FeCache::load_romlistmeta(
+	const FeRomList &romlist,
+	std::map<std::string, std::string> &info
+)
+{
+	bool success = load_cache( get_romlistmeta_filename( romlist ), info );
+	debug( "Load RomlistMeta Cache", romlist.get_romlist_name(), success );
+	if ( !success ) invalidate_romlistmeta( romlist );
+	_debug();
+	return success;
+}
+
+void FeCache::invalidate_romlistmeta(
+	const FeRomList &romlist
+)
+{
+	debug( "Invalidate RomlistMeta", romlist.get_romlist_name() );
+	delete_cache( get_romlistmeta_filename( romlist ) );
+
+	// Invalidate Romlist if it exists (will invalidate normally later otherwise)
+	if ( file_exists( get_romlist_filename( romlist ) ) )
+		invalidate_romlist( romlist );
+	_debug();
+}
+
+void FeCache::get_romlistmeta_data(
+	FeRomList &romlist,
+	std::map<std::string, std::string> &data
+)
+{
+	data["romlist_mtime"] = as_str( file_mtime( romlist.get_romlist_path() ) );
+}
+
+// Ensure RomlistMeta cache is valid, call this before load_globalfilter or load_filter
+bool FeCache::validate_romlistmeta(
+	FeRomList &romlist
+)
+{
+	debug( "Validate RomlistMeta", romlist.get_romlist_name() );
+	std::map<std::string, std::string> prev;
+	bool loaded = load_romlistmeta( romlist, prev );
+
+	std::map<std::string, std::string> next;
+	get_romlistmeta_data( romlist, next );
+	bool valid = ( prev == next );
+
+	if ( !valid )
+	{
+		if ( loaded )
+		{
+			debug( "Validate RomlistMeta", romlist.get_romlist_name(), false );
+			invalidate_romlistmeta( romlist );
+			_debug();
+		}
+		save_romlistmeta( romlist, next );
+	}
+
+	_debug();
+	return valid;
+}
+
+// -------------------------------------------------------------------------------------
+//
+// Display cache stores metadata about the given display
+// - Group clones, tag/fav modified times, globalfilter rules
+// - Used to detect both internal and external changes to the globalfilter
+//
+
+bool FeCache::save_display(
+	FeDisplayInfo &display,
+	FeRomList &romlist
+)
+{
+	std::map<std::string, std::string> next;
+	get_display_metadata( display, romlist, next );
+	return save_display( display, next );
+}
+
+bool FeCache::save_display(
+	const FeDisplayInfo &display,
+	const std::map<std::string, std::string> &info
+)
+{
+	bool success = save_cache( get_display_filename( display ), info );
+	debug( "Save Display Cache", display.get_name(), success );
+	if ( !success ) invalidate_display( display );
+	_debug();
+	return success;
+}
+
+bool FeCache::load_display(
+	const FeDisplayInfo &display,
+	std::map<std::string, std::string> &info
+)
+{
+	bool success = load_cache( get_display_filename( display ), info );
+	debug( "Load Display Cache", display.get_name(), success );
+	if ( !success ) invalidate_display( display );
+	_debug();
+	return success;
+}
+
+void FeCache::invalidate_display(
+	const FeDisplayInfo &display
+)
+{
+	debug( "Invalidate Display", display.get_name() );
+	delete_cache( get_display_filename( display ) );
+	// Invalidate Globalfilter, which causes all Filters to invalidate also
+	invalidate_globalfilter( display );
+	_debug();
+}
+
+// Ensure display cache is valid, call this before load_globalfilter or load_filter
+bool FeCache::validate_display(
+	FeDisplayInfo &display,
+	FeRomList &romlist
+)
+{
+	debug( "Validate Display", display.get_name() );
+	std::map<std::string, std::string> prev;
+	bool loaded = load_display( display, prev );
+
+	std::map<std::string, std::string> next;
+	get_display_metadata( display, romlist, next );
+	bool valid = ( prev == next );
+
+	if ( !valid )
+	{
+		if ( loaded )
+		{
+			debug( "Validate Display", display.get_name(), false );
+			invalidate_display( display );
+			_debug();
+		}
+		save_display( display, next );
+	}
+
+	_debug();
+	return valid;
+}
+
+// Returns a list of data that when changed will trigger display invalidation
+void FeCache::get_display_metadata(
+	FeDisplayInfo &display,
+	FeRomList &romlist,
+	std::map<std::string, std::string> &data
+)
+{
+	// romlist
+	data["group_clones"] = as_str( romlist.get_group_clones() );
+
+	// favs/tags
+	data["fav_mtime"] = as_str( file_mtime( romlist.get_fav_path() ) );
+	std::vector<std::string> tags = romlist.get_tag_names();
+	for ( std::vector<std::string>::iterator itt=tags.begin(); itt!=tags.end(); ++itt )
+		data["tag_" + (*itt) + "_mtime"] = as_str( file_mtime( romlist.get_tag_path(*itt) ) );
+
+	// filters
+	data["global_filter"] = get_filter_id( display.get_global_filter() );
+}
+
+// -------------------------------------------------------------------------------------
+//
+// Available cache stores a list of rom names for ALL emulators used by romlist
+// - Used to detect changes for FileIsAvailable rules
+//
+
+bool FeCache::save_available(
+	const FeRomList &romlist,
+	const std::map<std::string, std::vector<std::string>> &emu_roms
+)
+{
+	bool success = save_cache( get_available_filename( romlist ), emu_roms );
+	debug( "Save Available Cache", romlist.get_romlist_name(), success );
+	if ( !success ) invalidate_available( romlist );
+	_debug();
+	return success;
+}
+
+bool FeCache::load_available(
+	const FeRomList &romlist,
+	std::map<std::string, std::vector<std::string>> &emu_roms
+)
+{
+	bool success = load_cache( get_available_filename( romlist ), emu_roms );
+	debug( "Load Available Cache", romlist.get_romlist_name(), success );
+	if ( !success ) invalidate_available( romlist );
+	_debug();
+	return success;
+}
+
+void FeCache::invalidate_available(
+	const FeRomList &romlist
+)
+{
+	debug( "Invalidate Available", romlist.get_romlist_name() );
+	delete_cache( get_available_filename( romlist ) );
+	// Invalidate all Displays using this Romlist with FileIsAvailable info
+	invalidate_rominfo( romlist, { FeRomInfo::FileIsAvailable });
+	_debug();
+}
+
+// Ensure Available cache matches file system.
+// - Populates `emu_roms` with `gather_rom_names`, which may be reused by caller to avoid re-gathering valid results
+bool FeCache::validate_available(
+	FeRomList &romlist,
+	std::map<std::string, std::vector<std::string>> &emu_roms
+)
+{
+	debug( "Validate File Availability", romlist.get_romlist_name() );
+
+	// Exit early if cannot load
+	if ( !load_available( romlist, emu_roms ) )
+	{
+		_debug();
+		emu_roms.clear();
+		return false;
+	}
+
+	// Invalidate rominfo if any roms dont match
+	for ( std::map<std::string, std::vector<std::string>>::iterator ite=emu_roms.begin(); ite != emu_roms.end(); ++ite )
+	{
+		FeEmulatorInfo *emu = romlist.get_emulator( (*ite).first );
+		std::vector<std::string> names;
+		if ( emu ) emu->gather_rom_names( names );
+		if ( names != (*ite).second )
+		{
+			debug( "Validate File Availability", (*ite).first, false );
+			invalidate_available( romlist );
+			_debug();
+
+			emu_roms.clear();
+			_debug();
+			return false;
+		}
+	}
+
+	_debug();
+	return true;
+}
+
+// -------------------------------------------------------------------------------------
+//
+// Romlist Cache stores a copy of the romlist file contents
+// - Data is identical to `romlist.txt`, but in format that's faster to load
+//
+
+bool FeCache::save_romlist(
+	const FeRomList &romlist
+)
+{
+	bool success = save_cache( get_romlist_filename( romlist ), romlist );
+	debug( "Save Romlist Cache", romlist.get_romlist_name(), success );
+	if ( !success ) invalidate_romlist( romlist );
+	_debug();
+	return success;
+}
+
+bool FeCache::load_romlist(
+	FeRomList &romlist
+)
+{
+	bool success = load_cache( get_romlist_filename( romlist ), romlist );
+	debug( "Load Romlist Cache", romlist.get_romlist_name(), success );
+	if ( !success ) invalidate_romlist( romlist );
+	_debug();
+	return success;
+}
+
+void FeCache::invalidate_romlist(
+	const FeRomList &romlist
+)
+{
+	debug( "Invalidate Romlist", romlist.get_romlist_name() );
+	delete_cache( get_romlist_filename( romlist ) );
+	std::string romlist_name = romlist.get_romlist_name();
+
+	// Invalidate ALL displays using this romlist
+	for (std::vector<FeDisplayInfo>::const_iterator itd=(*m_displays).begin(); itd!=(*m_displays).end(); ++itd)
+	{
+		FeDisplayInfo display = (*itd);
 		if ( display.get_romlist_name() == romlist_name ) invalidate_display( display );
 	}
-#endif
+	_debug();
 }
 
+// -------------------------------------------------------------------------------------
 //
-// Clears all cache belonging to the given display (globalfilter and filters)
+// GlobalFilter Cache stores the results of the global filter
+// - It contains a list of roms much like the romlist, and may be loaded in its place
 //
-void FeCache::invalidate_display(
-	FeDisplayInfo &display
+
+bool FeCache::save_globalfilter(
+	const FeDisplayInfo &display,
+	const FeRomList &romlist
 )
 {
-#ifdef FE_CACHE_ENABLE
-	invalidate_globalfilter( display );
-	int filters_count = display.get_filter_count();
-	if ( filters_count == 0 ) filters_count = 1;
-	for ( int i=0; i<filters_count; i++ ) invalidate_filter( display, i );
-#endif
+	bool success = save_cache( get_globalfilter_filename( display ), romlist );
+	debug( "Save GlobalFilter Cache", display.get_name(), success );
+	if ( !success ) invalidate_globalfilter( display );
+	_debug();
+	return success;
 }
 
-//
-// Clears a cached globalfilter file
-//
+bool FeCache::load_globalfilter(
+	const FeDisplayInfo &display,
+	FeRomList &romlist
+)
+{
+	bool success = load_cache( get_globalfilter_filename( display ), romlist );
+	debug( "Load GlobalFilter Cache", display.get_name(), success );
+	if ( !success ) invalidate_globalfilter( display );
+	_debug();
+	return success;
+}
+
 void FeCache::invalidate_globalfilter(
-	FeDisplayInfo &display
+	const FeDisplayInfo &display
 )
 {
-#ifdef FE_CACHE_ENABLE
-	std::string filename = get_globalfilter_cache_filename( display );
-	if ( file_exists( filename ) ) delete_file( filename );
-#endif
+	debug( "Invalidate GlobalFilter", display.get_name() );
+	delete_cache( get_globalfilter_filename( display ) );
+	// Invalidate ALL filters for this display
+	int filters_count = std::max( display.get_filter_count(), 1 );
+	for ( int i=0; i<filters_count; i++ )
+		invalidate_filter( display, i );
+	_debug();
 }
 
+// -------------------------------------------------------------------------------------
 //
-// Clears a cached filter file
+// Filter Cache stores a set of indexes that reference roms in the romlist/globalfilter cache
 //
-void FeCache::invalidate_filter(
+
+bool FeCache::save_filter(
 	FeDisplayInfo &display,
-	int filter_index
+	const FeFilterEntry &entry,
+	const int filter_index
 )
 {
-#ifdef FE_CACHE_ENABLE
-	std::string filename = get_filter_cache_filename( display, filter_index );
-	if ( file_exists( filename ) ) delete_file( filename );
-#endif
+	FeFilter *f = display.get_filter_count()
+		? display.get_filter( filter_index )
+		: display.get_global_filter();
+
+	FeFilterIndexes indexes;
+	indexes.entry_to_index( entry );
+	indexes.set_size( f->get_size() );
+	indexes.set_filter_id( get_filter_id( f ) );
+
+	bool success = save_cache( get_filter_filename( display, filter_index ), indexes );
+	debug( "Save Filter Cache", display.get_name() + ":" + as_str(filter_index), success );
+	if ( !success ) invalidate_filter( display, filter_index );
+	_debug();
+	return success;
 }
 
+bool FeCache::load_filter(
+	FeDisplayInfo &display,
+	FeFilterEntry &entry,
+	const int filter_index,
+	const std::map<int, FeRomInfo*> &lookup
+)
+{
+	FeFilterIndexes indexes;
+	bool success = load_cache( get_filter_filename( display, filter_index ), indexes );
+	debug( "Load Filter Cache", display.get_name() + ":" + as_str(filter_index), success );
+	if ( success )
+	{
+		FeFilter *f = display.get_filter_count()
+			? display.get_filter( filter_index )
+			: display.get_global_filter();
+
+		if ( indexes.get_filter_id() != get_filter_id( f )
+			|| !indexes.index_to_entry( entry, lookup ))
+		{
+			invalidate_filter( display, filter_index );
+			_debug();
+			return false;
+		}
+
+		f->set_size( indexes.get_size() );
+	}
+	else
+		invalidate_filter( display, filter_index );
+
+	_debug();
+	return success;
+}
+
+void FeCache::invalidate_filter(
+	const FeDisplayInfo &display,
+	const int filter_index
+)
+{
+	debug( "Invalidate Filter", display.get_name() + ":" + as_str(filter_index) );
+	delete_cache( get_filter_filename( display, filter_index ) );
+	_debug();
+}
+
+// Returns a simple identifier string for the filter, by joining all its rules together
+// - Used to detect rule changes
+std::string FeCache::get_filter_id(
+	FeFilter *filter
+)
+{
+	std::string id = "";
+	id += as_str( filter->get_reverse_order() )+ ";";
+	id += as_str( filter->get_sort_by() ) + ";";
+
+	std::vector<FeRule> &rules = filter->get_rules();
+	for ( std::vector<FeRule>::iterator itr=rules.begin(); itr!=rules.end(); ++itr )
+	{
+		FeRule rule = *itr;
+		id += as_str( rule.get_target() ) + ";";
+		id += as_str( rule.get_comp() ) + ";";
+		id += rule.get_what() + ";";
+		id += as_str( rule.is_exception() ) + ";";
+	}
+
+	return id;
+}
+
+// -------------------------------------------------------------------------------------
+
 //
-// Clears cache for all displays using the given romlist, and a rule with a changed rominfo value
-// - Favourite, Tags, PlayedCount, PlayedTime
+// Invalidate all Globalfilters and Filters using the Romlist with the given RomInfo targets
+// Called when rom info has changed, such as Tags and Stats
 //
 void FeCache::invalidate_rominfo(
-	const std::string &romlist_name,
-	FeRomInfo::Index target
+	const FeRomList &romlist,
+	const std::set<FeRomInfo::Index> targets
 )
 {
-#ifdef FE_CACHE_ENABLE
-	for (std::vector<FeDisplayInfo>::const_iterator itr=(*m_displays).begin(); itr!=(*m_displays).end(); ++itr)
+	std::string t = "";
+	for (std::set<FeRomInfo::Index>::iterator itt=targets.begin(); itt!=targets.end(); ++itt)
+		t += (std::distance(targets.begin(), itt) ? ", " : "") + (std::string)FeRomInfo::indexStrings[*itt];
+	debug( "Invalidate Rominfo", t );
+
+	std::string romlist_name = romlist.get_romlist_name();
+	for (std::vector<FeDisplayInfo>::const_iterator itd=(*m_displays).begin(); itd!=(*m_displays).end(); ++itd)
 	{
-		FeDisplayInfo display = (*itr);
-		if ( display.get_romlist_name() == romlist_name )
+		FeDisplayInfo display = (*itd);
+		if ( display.get_romlist_name() != romlist_name ) continue;
+
+		// Clear the globalfilter if it uses the target (also clears other filters)
+		FeFilter *global_filter = display.get_global_filter();
+		if ( global_filter && global_filter->test_for_targets( targets ) )
 		{
-			// Clear the globalfilter if it uses the target
-			FeFilter *global_filter = display.get_global_filter();
-			bool changed = global_filter && global_filter->test_for_target( target );
-			if ( changed ) invalidate_globalfilter( display );
-
-			int filters_count = display.get_filter_count();
-
-			// If no filters there's still a single cache file containing entire romlist
-			if ( changed && filters_count == 0 ) invalidate_filter( display, 0 );
-
-			// Clear filters that are using the target, or if the romlist has changed
-			for ( int i=0; i<filters_count; i++ )
-			{
-				if ( changed || display.get_filter( i )->test_for_target( target ) )
-				{
-					invalidate_filter( display, i );
-				}
-			}
+			invalidate_globalfilter( display );
+			continue;
 		}
+
+		// Clear filters that are using the target
+		int filters_count = display.get_filter_count();
+		for ( int i=0; i<filters_count; i++ )
+			if ( display.get_filter( i )->test_for_targets( targets ) )
+				invalidate_filter( display, i );
 	}
-#endif
+	_debug();
 }
 
 // -------------------------------------------------------------------------------------
+//
+// Stats Cache holds rom stats for the given emulator
+//
 
-//
-// Saves romhash to cache file
-//
-bool FeCache::save_romhash_cache(
-	const std::string &romlist_name,
-	std::set<std::string> &emu_set,
-	size_t &hash
+bool FeCache::save_stats(
+	const std::string &emulator
 )
 {
-#ifdef FE_CACHE_ENABLE
-	std::string filename = get_romhash_cache_filename( romlist_name );
-	if ( filename.empty() ) return false;
-	nowide::ofstream file( filename, std::ios::binary );
-	if ( !file.is_open() ) return false;
-
-	try
-	{
-		{	// block flushes archive
-			OutputArchive archive( file );
-			archive( emu_set, hash );
-		}
-		file.close();
-		return true;
-	}
-	catch (...)
-	{
-		file.close();
-		return false;
-	}
-#else
-	return false;
-#endif
+	if ( m_stats_cache.find(emulator) == m_stats_cache.end() ) return false;
+	bool success = save_cache( get_stats_filename( emulator ), m_stats_cache[emulator] );
+	debug( "Save Stats Cache", emulator, success );
+	if ( !success ) invalidate_stats( emulator );
+	_debug();
+	return success;
 }
 
-//
-// Loads romhash file
-//
-bool FeCache::load_romhash_cache(
-	const std::string &romlist_name,
-	std::set<std::string> &emu_set,
-	size_t &hash
+bool FeCache::load_stats(
+	const std::string &emulator
 )
 {
-#ifdef FE_CACHE_ENABLE
-	std::string filename = get_romhash_cache_filename( romlist_name );
-	if ( !file_exists( filename ) ) return false;
-	nowide::ifstream file( filename, std::ios::binary );
-	if ( !file.is_open() ) return false;
-
-	try
-	{
-		{	// block flushes archive
-			InputArchive archive( file );
-			archive( emu_set, hash );
-		}
-		file.close();
-		return true;
-	}
-	catch ( ... )
-	{
-		file.close();
-		return false;
-	}
-#else
-	return false;
-#endif
+	bool success = load_cache( get_stats_filename( emulator ), m_stats_cache[emulator] );
+	debug( "Load Stats Cache", emulator, success );
+	if ( !success ) invalidate_stats( emulator );
+	_debug();
+	return success;
 }
 
-// -------------------------------------------------------------------------------------
-
-//
-// Saves romlist to cache file
-//
-bool FeCache::save_romlist_cache(
-	const std::string &romlist_name,
-	FeRomList &romlist
+void FeCache::invalidate_stats(
+	const std::string &emulator
 )
 {
-#ifdef FE_CACHE_ENABLE
-	std::string filename = get_romlist_cache_filename( romlist_name );
-	if ( filename.empty() ) return false;
-	nowide::ofstream file( filename, std::ios::binary );
-	if ( !file.is_open() ) return false;
-
-	try
-	{
-		{	// block flushes archive
-			OutputArchive archive( file );
-			archive( romlist );
-		}
-		file.close();
-		return true;
-	}
-	catch (...)
-	{
-		file.close();
-		invalidate_romlist( romlist_name );
-		return false;
-	}
-#else
-	return false;
-#endif
+	debug( "Invalidate Stats", emulator );
+	delete_cache( get_stats_filename( emulator ) );
+	_debug();
 }
 
-//
-// Loads romlist file and updates romlist
-//
-bool FeCache::load_romlist_cache(
-	const std::string &romlist_name,
-	FeRomList &romlist
-)
-{
-#ifdef FE_CACHE_ENABLE
-	std::string filename = get_romlist_cache_filename( romlist_name );
-	if ( !file_exists( filename ) ) return false;
-	nowide::ifstream file( filename, std::ios::binary );
-	if ( !file.is_open() ) return false;
-
-	try
-	{
-		{	// block flushes archive
-			InputArchive archive( file );
-			archive( romlist );
-		}
-		file.close();
-		return true;
-	}
-	catch ( ... )
-	{
-		file.close();
-		invalidate_romlist( romlist_name );
-		return false;
-	}
-#else
-	return false;
-#endif
-}
-
-// -------------------------------------------------------------------------------------
-
-//
-// Saves globalfilter to cache file
-//
-bool FeCache::save_globalfilter_cache(
-	FeDisplayInfo &display,
-	FeRomList &romlist
-)
-{
-#ifdef FE_CACHE_ENABLE
-	std::string filename = get_globalfilter_cache_filename( display );
-	if ( filename.empty() ) return false;
-	nowide::ofstream file( filename, std::ios::binary );
-	if ( !file.is_open() ) return false;
-
-	try
-	{
-		{	// block flushes archive
-			OutputArchive archive( file );
-			archive( romlist );
-		}
-		file.close();
-		return true;
-	}
-	catch (...)
-	{
-		file.close();
-		invalidate_globalfilter( display );
-		return false;
-	}
-#else
-	return false;
-#endif
-}
-
-//
-// Loads globalfilter file and updates romlist
-//
-bool FeCache::load_globalfilter_cache(
-	FeDisplayInfo &display,
-	FeRomList &romlist
-)
-{
-#ifdef FE_CACHE_ENABLE
-	std::string filename = get_globalfilter_cache_filename( display );
-	if ( !file_exists( filename ) ) return false;
-	nowide::ifstream file( filename, std::ios::binary );
-	if ( !file.is_open() ) return false;
-
-	try
-	{
-		{	// block flushes archive
-			InputArchive archive( file );
-			archive( romlist );
-		}
-		file.close();
-		return true;
-	}
-	catch ( ... )
-	{
-		file.close();
-		invalidate_globalfilter( display );
-		return false;
-	}
-#else
-	return false;
-#endif
-}
-
-// -------------------------------------------------------------------------------------
-
-//
-// Saves filter to cache file
-//
-bool FeCache::save_filter_cache(
-	FeDisplayInfo &display,
-	FeFilterEntry &entry,
-	int filter_index
-)
-{
-#ifdef FE_CACHE_ENABLE
-	std::string filename = get_filter_cache_filename( display, filter_index );
-	if ( filename.empty() ) return false;
-	nowide::ofstream file( filename, std::ios::binary );
-	if ( !file.is_open() ) return false;
-
-	try
-	{
-		// Create indexes, which is what gets cached
-		FeFilterIndexes indexes;
-		indexes.entry_to_index( entry );
-		{	// block flushes archive
-			OutputArchive archive( file );
-			archive( indexes );
-		}
-		file.close();
-		return true;
-	}
-	catch (...)
-	{
-		file.close();
-		invalidate_filter( display, filter_index );
-		return false;
-	}
-#else
-	return false;
-#endif
-}
-
-//
-// Loads cache file and updates romlist filter
-//
-bool FeCache::load_filter_cache(
-	FeDisplayInfo &display,
-	FeFilterEntry &entry,
-	int filter_index,
-	std::map<int, FeRomInfo*> &lookup
-)
-{
-#ifdef FE_CACHE_ENABLE
-	std::string filename = get_filter_cache_filename( display, filter_index );
-	if ( !file_exists( filename ) ) return false;
-	nowide::ifstream file( filename, std::ios::binary );
-	if ( !file.is_open() ) return false;
-
-	try
-	{
-		FeFilterIndexes indexes;
-		{	// block flushes archive
-			InputArchive archive( file );
-			archive( indexes );
-		}
-		// Restore indexes back into entries
-		indexes.index_to_entry( entry, lookup );
-		file.close();
-		return true;
-	}
-	catch ( ... )
-	{
-		file.close();
-		invalidate_filter( display, filter_index );
-		return false;
-	}
-#else
-	return false;
-#endif
-}
-
-// -------------------------------------------------------------------------------------
-
-//
-// Saves stats to cache file
-//
-bool FeCache::save_stats_cache(
-	std::string &emulator
-)
-{
-#ifdef FE_CACHE_ENABLE
-	if ( FeCache::stats_cache.find(emulator) == FeCache::stats_cache.end() ) return false;
-	std::string filename = get_stats_cache_filename( emulator );
-	if ( filename.empty() ) return false;
-	nowide::ofstream file( filename, std::ios::binary );
-	if ( !file.is_open() ) return false;
-
-	try
-	{
-		{	// block flushes archive
-			OutputArchive archive( file );
-			archive( FeCache::stats_cache[emulator] );
-		}
-		file.close();
-		return true;
-	}
-	catch (...)
-	{
-		file.close();
-		return false;
-	}
-#else
-	return false;
-#endif
-}
-
-//
-// Loads cache file and updates stats
-//
-bool FeCache::load_stats_cache(
-	std::string &emulator
-)
-{
-#ifdef FE_CACHE_ENABLE
-	std::string filename = get_stats_cache_filename( emulator );
-	if ( !file_exists( filename ) ) return false;
-	nowide::ifstream file( filename, std::ios::binary );
-	if ( !file.is_open() ) return false;
-
-	try
-	{
-		{	// block flushes archive
-			InputArchive archive( file );
-			archive( FeCache::stats_cache[emulator] );
-		}
-		file.close();
-		return true;
-	}
-	catch ( ... )
-	{
-		file.close();
-		FeCache::stats_cache[emulator] = {};
-		return false;
-	}
-#else
-	return false;
-#endif
-}
-
-// -------------------------------------------------------------------------------------
-
-//
-// Ensure stats cache entry exists for emulator
-// - If not, read all stats files and create one
-//
-bool FeCache::confirm_stats_cache(
+// Ensure in-memory stats entry exists for the given emulator
+bool FeCache::validate_stats(
 	const std::string &path,
-	std::string &emulator
+	const std::string &emulator
 ) {
-#ifdef FE_CACHE_ENABLE
-	// Exit if already loaded
-	if ( FeCache::stats_cache.find(emulator) != FeCache::stats_cache.end() ) return true;
+	// Return success if already loaded
+	if ( m_stats_cache.find(emulator) != m_stats_cache.end() ) return true;
 
-	// Exit if successfully loaded from cache
-	if ( load_stats_cache( emulator ) ) return true;
+	// Return success if successfully loaded from cache
+	if ( load_stats( emulator ) ) return true;
 
-	// Create new stats cache objectfor emulator
-	FeCache::stats_cache[emulator] = FeListStats();
+	// Abort if invalid path to load stats from
+	if ( path.empty() ) return false;
+
+	// Abort if there are no stats to load
 	std::vector<std::string> file_list;
 	std::string stats_path = path + emulator + "/";
-
-	// Exit if no stats to load
 	if ( !get_basename_from_extension( file_list, stats_path, FE_STAT_FILE_EXTENSION, true ) ) return false;
 
-	// Parse all stat files into cache object
+	// Create new stats cache object for emulator
+	m_stats_cache[emulator] = {};
+
+	// Parse ALL stat files into cache object
 	std::string played_count;
 	std::string played_time;
-	for ( std::vector<std::string>::iterator itr=file_list.begin(); itr != file_list.end(); ++itr )
+	for ( std::vector<std::string>::iterator itf=file_list.begin(); itf != file_list.end(); ++itf )
 	{
-		nowide::ifstream stat_file( (stats_path + *itr + FE_STAT_FILE_EXTENSION).c_str() );
-		if ( !stat_file.is_open() ) break;
+		nowide::ifstream stat_file( stats_path + *itf + FE_STAT_FILE_EXTENSION );
+		if ( !stat_file.is_open() ) continue;
+
 		played_count = "0";
 		played_time = "0";
 		if ( stat_file.good() ) getline( stat_file, played_count );
 		if ( stat_file.good() ) getline( stat_file, played_time );
-		FeCache::stats_cache[emulator].list[*itr] = FeStat( played_count, played_time );
 		stat_file.close();
+
+		m_stats_cache[emulator][*itf] = { played_count, played_time };
 	}
 
-	// Save new stats cache for next time
-	save_stats_cache(emulator);
-	return true;
-#else
-	return false;
-#endif
+	// Save stats cache for next time
+	return save_stats( emulator );
 }
 
-//
+// Clear the in-memory stats cache, called when a new romlist is loaded
+// - If not cleared in-memory stats will simply grow to contain all emulator stats
+void FeCache::clear_stats()
+{
+	m_stats_cache.clear();
+}
+
 // Load stats from cache to rominfo
 // - Always returns true to prevent callee attempting to load stats that dont exist
-//
 bool FeCache::get_stats_info(
 	const std::string &path,
 	std::vector<std::string> &rominfo
-) {
-#ifdef FE_CACHE_ENABLE
+)
+{
+	// Reset all info to default
+	std::set<FeRomInfo::Index>::iterator index = FeRomInfo::Stats.begin();
+	int size = (int)FeRomInfo::Stats.size();
+	for ( int i=0; i<size; i++ )
+		rominfo[ *index + i ] = "0";
+
+	// Exit early if there are NO stats at all
 	std::string emulator = rominfo[FeRomInfo::Emulator];
+	if ( !validate_stats( path, emulator ) ) return true;
+
+	// Exit early if there are NO stats for this rom
 	std::string romname = rominfo[FeRomInfo::Romname];
+	if ( m_stats_cache[emulator].find(romname) == m_stats_cache[emulator].end() ) return true;
 
-	// Exit if no stats for this emulator, or this rom
-	if ( !confirm_stats_cache( path, emulator ) ) return true;
-	if ( FeCache::stats_cache[emulator].list.find(romname) == FeCache::stats_cache[emulator].list.end() ) return true;
+	// Copy available stats to the rominfo object
+	std::vector<std::string> &info = m_stats_cache[emulator][romname];
+	int info_size = info.size();
+	for ( int i=0; i<info_size; i++ )
+		rominfo[ *index + i ] = info[i];
 
-	// Copy stats to rominfo object
-	rominfo[FeRomInfo::PlayedCount] = FeCache::stats_cache[emulator].list[romname].played_count;
-	rominfo[FeRomInfo::PlayedTime] = FeCache::stats_cache[emulator].list[romname].played_time;
 	return true;
-#else
-	return false;
-#endif
 }
 
-//
-// Save stats from rominfo to cache
-//
+// Copy stats from rominfo to cache, then save
 bool FeCache::set_stats_info(
 	const std::string &path,
-	std::vector<std::string> &rominfo
+	const std::vector<std::string> &rominfo
 ) {
-#ifdef FE_CACHE_ENABLE
+	// Exit if there's an error creating cache for stat
+	// - This shouldn't happen, since this method is only called AFTER get_stats_info
 	std::string emulator = rominfo[FeRomInfo::Emulator];
+	if ( !validate_stats( path, emulator ) ) return true;
+
+	// Update stats in cache object
 	std::string romname = rominfo[FeRomInfo::Romname];
-	std::string played_count = rominfo[FeRomInfo::PlayedCount];
-	std::string played_time = rominfo[FeRomInfo::PlayedTime];
+	m_stats_cache[emulator][romname].clear();
+	for ( std::set<FeRomInfo::Index>::iterator its=FeRomInfo::Stats.begin(); its != FeRomInfo::Stats.end(); ++its )
+		m_stats_cache[emulator][romname].push_back( rominfo[ *its ] );
 
-	// Exit if error creating cache for stat
-	if ( !confirm_stats_cache( path, emulator ) ) return true;
-
-	// Update stats in cache object, and save it
-	FeCache::stats_cache[emulator].list[romname] = FeStat( played_count, played_time );
-	save_stats_cache( emulator );
-	return true;
-#else
-	return false;
-#endif
+	// Save the updated stats cache
+	return save_stats( emulator );
 }
+
+#endif

--- a/src/fe_cache.hpp
+++ b/src/fe_cache.hpp
@@ -1,56 +1,10 @@
 #ifndef FE_CACHE_HPP
 #define FE_CACHE_HPP
 
-#ifndef FE_VERSION_NUM
-#define FE_VERSION_NUM 1
-#endif
-
 #include "fe_romlist.hpp"
 #include "fe_util.hpp"
 
 #include <algorithm>
-
-#include "cereal/cereal.hpp"
-#include <cereal/types/map.hpp>
-
-// A single stat item
-class FeStat
-{
-public:
-	std::string played_count;
-	std::string played_time;
-
-	FeStat() {}
-	FeStat( std::string count, std::string time ):
-		played_count( count ),
-		played_time( time )
-	{}
-
-	template<class Archive>
-	void serialize( Archive &archive, std::uint32_t const version )
-	{
-		if ( version != FE_VERSION_NUM ) throw "Invalid FeStat cache";
-		archive( played_count, played_time );
-	}
-};
-
-CEREAL_CLASS_VERSION( FeStat, FE_VERSION_NUM );
-
-// Holds a list of named stats
-class FeListStats
-{
-public:
-	std::map<std::string, FeStat> list = std::map<std::string, FeStat>{};
-
-	template<class Archive>
-	void serialize( Archive &archive, std::uint32_t const version )
-	{
-		if ( version != FE_VERSION_NUM ) throw "Invalid FeListStats cache";
-		archive( list );
-	}
-};
-
-CEREAL_CLASS_VERSION( FeListStats, FE_VERSION_NUM );
 
 class FeCache
 {
@@ -58,12 +12,153 @@ private:
 
 	static std::vector<FeDisplayInfo>* m_displays;
 	static std::string m_config_path;
-	static std::map<std::string, FeListStats> stats_cache;
+	static std::map<std::string, std::map<std::string, std::vector<std::string>>> m_stats_cache;
+	static int m_indent;
+
+	static void debug(
+		std::string value,
+		std::string filename = "",
+		bool success = true
+	);
+
+	static void _debug();
+
+	static std::string get_romlistmeta_filename(
+		const FeRomList &romlist
+	);
+
+	static std::string get_display_filename(
+		const FeDisplayInfo &display
+	);
+
+	static std::string get_available_filename(
+		const FeRomList &romlist
+	);
+
+	static std::string get_romlist_filename(
+		const FeRomList &romlist
+	);
+
+	static std::string get_globalfilter_filename(
+		const FeDisplayInfo &display
+	);
+
+	static std::string get_filter_filename(
+		const FeDisplayInfo &display,
+		const int filter_index
+	);
+
+	static std::string get_stats_filename(
+		const std::string &emulator
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	template <typename T>
+	static bool save_cache(
+		const std::string &filename,
+		const T &info
+	);
+
+	template <typename T>
+	static bool load_cache(
+		const std::string &filename,
+		T &info
+	);
+
+	static void delete_cache(
+		const std::string &filename
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	static bool save_romlistmeta(
+		const FeRomList &romlist,
+		const std::map<std::string, std::string> &info
+	);
+
+	static bool load_romlistmeta(
+		const FeRomList &romlist,
+		std::map<std::string, std::string> &info
+	);
+
+	static void invalidate_romlistmeta(
+		const FeRomList &romlist
+	);
+
+	static void get_romlistmeta_data(
+		FeRomList &romlist,
+		std::map<std::string, std::string> &data
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	static bool save_display(
+		const FeDisplayInfo &display,
+		const std::map<std::string, std::string> &info
+	);
+
+	static bool load_display(
+		const FeDisplayInfo &display,
+		std::map<std::string, std::string> &info
+	);
+
+	static void invalidate_display(
+		const FeDisplayInfo &display
+	);
+
+	static void get_display_metadata(
+		FeDisplayInfo &display,
+		FeRomList &romlist,
+		std::map<std::string, std::string> &data
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	static void invalidate_available(
+		const FeRomList &romlist
+	);
+
+	static void invalidate_romlist(
+		const FeRomList &romlist
+	);
+
+	static void invalidate_globalfilter(
+		const FeDisplayInfo &display
+	);
+
+	static void invalidate_filter(
+		const FeDisplayInfo &display,
+		const int filter_index
+	);
+
+	static std::string get_filter_id(
+		FeFilter *filter
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	static bool save_stats(
+		const std::string &emulator
+	);
+
+	static bool load_stats(
+		const std::string &emulator
+	);
+
+	static void invalidate_stats(
+		const std::string &emulator
+	);
+
+	static bool validate_stats(
+		const std::string &path,
+		const std::string &emulator
+	);
 
 public:
 
 	static void set_config_path(
-		std::string path
+		const std::string path
 	);
 
 	static void set_displays(
@@ -72,124 +167,90 @@ public:
 
 	// ----------------------------------------------------------------------------------
 
-	static std::string get_romhash_cache_filename(
-		const std::string &romlist_name
-	);
-
-	static std::string get_romlist_cache_filename(
-		const std::string &romlist_name
-	);
-
-	static std::string get_globalfilter_cache_filename(
-		FeDisplayInfo &display
-	);
-
-	static std::string get_filter_cache_filename(
-		FeDisplayInfo &display,
-		int filter_index
-	);
-
-	static std::string get_stats_cache_filename(
-		std::string &emulator
+	static bool validate_romlistmeta(
+		FeRomList &romlist
 	);
 
 	// ----------------------------------------------------------------------------------
 
-	static void invalidate_romlist(
-		const std::string &romlist_name
-	);
-
-	static void invalidate_display(
-		FeDisplayInfo &display
-	);
-
-	static void invalidate_globalfilter(
-		FeDisplayInfo &display
-	);
-
-	static void invalidate_filter(
+	static bool save_display(
 		FeDisplayInfo &display,
-		int filter_index
+		FeRomList &romlist
 	);
+
+	static bool validate_display(
+		FeDisplayInfo &display,
+		FeRomList &romlist
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	static bool save_available(
+		const FeRomList &romlist,
+		const std::map<std::string, std::vector<std::string>> &emu_roms
+	);
+
+	static bool load_available(
+		const FeRomList &romlist,
+		std::map<std::string, std::vector<std::string>> &emu_roms
+	);
+
+	static bool validate_available(
+		FeRomList &romlist,
+		std::map<std::string, std::vector<std::string>> &emu_roms
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	static bool save_romlist(
+		const FeRomList &romlist
+	);
+
+	static bool load_romlist(
+		FeRomList &romlist
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	static bool save_globalfilter(
+		const FeDisplayInfo &display,
+		const FeRomList &romlist
+	);
+
+	static bool load_globalfilter(
+		const FeDisplayInfo &display,
+		FeRomList &romlist
+	);
+
+	// ----------------------------------------------------------------------------------
+
+	static bool save_filter(
+		FeDisplayInfo &display,
+		const FeFilterEntry &entry,
+		const int filter_index
+	);
+
+	static bool load_filter(
+		FeDisplayInfo &display,
+		FeFilterEntry &entry,
+		const int filter_index,
+		const std::map<int, FeRomInfo*> &lookup
+	);
+
+	// ----------------------------------------------------------------------------------
 
 	static void invalidate_rominfo(
-		const std::string &romlist_name,
-		FeRomInfo::Index target
+		const FeRomList &romlist,
+		const std::set<FeRomInfo::Index> targets
 	);
 
 	// ----------------------------------------------------------------------------------
 
-	static bool save_romhash_cache(
-		const std::string &romlist_name,
-		std::set<std::string> &emu_set,
-		size_t &hash
-	);
-
-	static bool load_romhash_cache(
-		const std::string &romlist_name,
-		std::set<std::string> &emu_set,
-		size_t &hash
-	);
-
-	// ----------------------------------------------------------------------------------
-
-	static bool save_romlist_cache(
-		const std::string &romlist_name,
-		FeRomList &romlist
-	);
-
-	static bool load_romlist_cache(
-		const std::string &romlist_name,
-		FeRomList &romlist
-	);
-
-	// ----------------------------------------------------------------------------------
-
-	static bool save_globalfilter_cache(
-		FeDisplayInfo &display,
-		FeRomList &romlist
-	);
-
-	static bool load_globalfilter_cache(
-		FeDisplayInfo &display,
-		FeRomList &romlist
-	);
-
-	// ----------------------------------------------------------------------------------
-
-	static bool save_filter_cache(
-		FeDisplayInfo &display,
-		FeFilterEntry &entry,
-		int filter_index
-	);
-
-	static bool load_filter_cache(
-		FeDisplayInfo &display,
-		FeFilterEntry &entry,
-		int filter_index,
-		std::map<int, FeRomInfo*> &lookup
-	);
-
-	// ----------------------------------------------------------------------------------
-
-	static bool save_stats_cache(
-		std::string &emulator
-	);
-
-	static bool load_stats_cache(
-		std::string &emulator
-	);
-
-	// ----------------------------------------------------------------------------------
-
-	static bool confirm_stats_cache(
-		const std::string &path,
-		std::string &emulator
-	);
+	static void clear_stats();
 
 	static bool set_stats_info(
 		const std::string &path,
-		std::vector<std::string> &rominfo
+		const std::vector<std::string> &rominfo
 	);
 
 	static bool get_stats_info(

--- a/src/fe_config.cpp
+++ b/src/fe_config.cpp
@@ -539,8 +539,6 @@ bool FeEmulatorEditMenu::save( FeConfigContext &ctx )
 	confirm_directory( filename, FE_EMULATOR_SUBDIR );
 
 	const std::string name = m_emulator->get_info( FeEmulatorInfo::Name );
-	FeCache::invalidate_romlist( name );
-
 	filename += FE_EMULATOR_SUBDIR;
 	filename += name;
 	filename += FE_EMULATOR_FILE_EXTENSION;
@@ -1015,11 +1013,7 @@ bool FeFilterEditMenu::save( FeConfigContext &ctx )
 		// right now we just arbitrarily sort players, playcount and playtime in "reverse" order so
 		// higher values are first.
 		//
-		bool reverse_order = (( sort_by == FeRomInfo::Players )
-			|| ( sort_by == FeRomInfo::PlayedCount )
-			|| ( sort_by == FeRomInfo::PlayedTime ));
-
-		f->set_reverse_order( reverse_order );
+		f->set_reverse_order( FeRomInfo::isNumeric( sort_by ) );
 
 		std::string limit_str = ctx.opt_list[ sort_pos + 1 ].get_value();
 		int list_limit = as_int( limit_str );
@@ -1140,9 +1134,6 @@ bool FeDisplayEditMenu::save( FeConfigContext &ctx )
 	FeDisplayInfo *display = ctx.fe_settings.get_display( m_index );
 	if ( display )
 	{
-		// Clear this displays cache when its settings have changed
-		FeCache::invalidate_display( *display );
-
 		for ( int i=0; i< FeDisplayInfo::LAST_INDEX; i++ )
 		{
 			if (( i == FeDisplayInfo::InCycle ) || ( i == FeDisplayInfo::InMenu ))

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -735,18 +735,16 @@ void FeSettings::init_display()
 			list_path = temp;
 	}
 
-	if (
-		m_rl.load_romlist(
-			list_path,
-			romlist_name,
-			m_displays[m_current_display],
-			m_group_clones,
-			m_track_usage
-		) == false
-	)
-	{
+	if ( m_rl.load_romlist(
+		list_path,
+		romlist_name,
+		m_displays[m_current_display],
+		m_group_clones,
+		m_track_usage
+	))
+		m_rl.create_filters( m_displays[m_current_display] );
+	else
 		FeLog() << "Error opening romlist: " << romlist_name << std::endl;
-	}
 
 	m_path_cache.clear();
 }
@@ -1223,27 +1221,13 @@ const std::string &FeSettings::get_rom_info_absolute( int filter_index, int rom_
 	if ( get_filter_size( filter_index ) < 1 )
 		return FE_EMPTY_STRING;
 
-	// Make sure we have file availability information if user is requesting it.
-	if ( index == FeRomInfo::FileIsAvailable )
-		m_rl.get_file_availability();
-
-	// Make sure we have played stats information if user is requesting it.
-	bool load_stats = m_track_usage &&
-		(( index == FeRomInfo::PlayedCount ) || ( index == FeRomInfo::PlayedTime ));
+	// Make sure we have additional fields if user is requesting them.
+	if ( index == FeRomInfo::FileIsAvailable ) m_rl.get_file_availability();
+	if ( FeRomInfo::isStat( index )) m_rl.get_played_stats();
 
 	// handle situation where we are currently showing a search result
-	//
-	if ( !m_current_search.empty()
-			&& ( get_current_filter_index() == filter_index ))
-	{
-		if ( load_stats )
-			m_current_search[ rom_index ]->load_stats( m_config_path + FE_STATS_SUBDIR );
-
+	if ( !m_current_search.empty() && ( get_current_filter_index() == filter_index ))
 		return m_current_search[ rom_index ]->get_info( index );
-	}
-
-	if ( load_stats )
-		m_rl.load_stats( filter_index, rom_index );
 
 	return m_rl.lookup( filter_index, rom_index ).get_info( index );
 }
@@ -2469,13 +2453,7 @@ bool FeSettings::update_stats( int play_count, int play_time )
 
 	rom->update_stats( path, play_count, play_time );
 
-	bool fixed = m_rl.fix_filters( m_displays[m_current_display], FeRomInfo::PlayedCount );
-	fixed |= m_rl.fix_filters( m_displays[m_current_display], FeRomInfo::PlayedTime );
-
-	// Invalidate all cache files using stats in their rules
-	std::string romlist_name = m_displays[m_current_display].get_romlist_name();
-	FeCache::invalidate_rominfo( romlist_name, FeRomInfo::PlayedCount );
-	FeCache::invalidate_rominfo( romlist_name, FeRomInfo::PlayedTime );
+	bool fixed = m_rl.fix_filters( m_displays[m_current_display], FeRomInfo::Stats );
 
 	if ( fixed && ( &m_rl.lookup( filter_index, rom_index ) != rom ))
 	{
@@ -4357,7 +4335,7 @@ void FeSettings::update_romlist_after_edit(
                 //
 		int i=0;
                 outfile << "#" << FeRomInfo::indexStrings[i++];
-                while ( i < FeRomInfo::Favourite )
+                while ( i < FeRomInfo::LAST_INFO )
                         outfile << ";" << FeRomInfo::indexStrings[i++];
                 outfile << std::endl;
 
@@ -4391,7 +4369,6 @@ void FeSettings::update_romlist_after_edit(
 	if ( ( u_type == EraseEntry ) || (( u_type == UpdateEntry ) && !( original == replacement )) )
 		m_rl.mark_favs_and_tags_changed();
 
-	FeCache::invalidate_romlist( romlist_name );
 	m_rl.create_filters( m_displays[m_current_display] );
 }
 

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -276,8 +276,6 @@ private:
 		const std::string &,
 		const std::string & );
 
-	void validate_romlist();
-
 	void init_display();
 	void load_state();
 	void clear();

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -854,17 +854,22 @@ bool confirm_directory( const std::string &base, const std::string &sub )
 	return retval;
 }
 
-std::string as_str( int i )
+std::string as_str( const int i )
 {
 	return std::to_string( i );
 }
 
-std::string as_str( size_t t )
+std::string as_str( const size_t t )
 {
 	return std::to_string( t );
 }
 
-std::string as_str( float f, int decimals )
+std::string as_str( const time_t t )
+{
+	return std::to_string( t );
+}
+
+std::string as_str( const float f, const int decimals )
 {
 	std::ostringstream ss;
 	ss << std::setprecision( decimals ) << std::fixed << f;
@@ -1897,27 +1902,4 @@ bool hex_to_color( std::string hex, sf::Color &dest_color )
 	{
 		return false;
 	}
-}
-
-//
-// Returns a hash for all subdirs and filenames within the given paths
-// - Can be compared later to check if the given paths have had files added, removed, or renamed
-//
-size_t get_path_content_hash( std::set<std::string> &paths )
-{
-	std::string value = "";
-	for ( std::set<std::string>::const_iterator itr=paths.begin(); itr!=paths.end(); ++itr )
-	{
-		std::vector<std::string> temp_list;
-		std::vector<std::string> ignore_list;
-		if ( !get_filename_from_base(temp_list, ignore_list, *itr, "", 0)) continue;
-
-		// concat the entire listing as a string
-		std::ostringstream imploded;
-		std::copy(temp_list.begin(), temp_list.end(), std::ostream_iterator<std::string>(imploded));
-		value += imploded.str();
-	}
-
-	// return a hash of the value
-	return std::hash<std::string>{}(value);
 }

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -284,17 +284,22 @@ void delete_file( const std::string &file );
 //
 // Return integer as a string
 //
-std::string as_str( int i );
+std::string as_str( const int i );
 
 //
 // Return size_t as a string
 //
-std::string as_str( size_t t );
+std::string as_str( const size_t t );
+
+//
+// Return time as a string
+//
+std::string as_str( const time_t t );
 
 //
 // Return float as a string
 //
-std::string as_str( float f, int decimals=3 );
+std::string as_str( const float f, const int decimals=3 );
 
 //
 // Return string as integer
@@ -394,5 +399,3 @@ void hide_console();
 // - Returns true on success
 //
 bool hex_to_color( std::string hex, sf::Color &dest_color );
-
-size_t get_path_content_hash( std::set<std::string> &paths );

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1236,8 +1236,7 @@ bool FeVM::on_new_layout()
 		if ( ps == FeSettings::Intro_Showing )
 			return false; // silent fail if intro is not found
 		else
-			FeLog() << " ! Script file not found: " << path
-				<< " (" << filename << ")" << std::endl;
+			FeLog() << " ! Script file not found: " << path << filename << std::endl;
 	}
 
 
@@ -1248,8 +1247,7 @@ bool FeVM::on_new_layout()
 	if ( !skip_layout && ( ps == FeSettings::Layout_Showing ))
 	{
 		fep->set_layout_loaded( true );
-		FeLog() << " - Loaded layout: " << rep_path
-			<< " (" << filename << ")" << std::endl;
+		FeLog() << " - Loaded layout: " << rep_path << filename << std::endl;
 	}
 
 	// To avoid frame delay of nested surfaces we have to sort them here
@@ -2426,8 +2424,7 @@ void FeVM::do_nut( const char *script_file )
 
 	if ( !internal_do_nut( path, script_file ) )
 	{
-		FeLog() << "Error, file not found: " << path
-			<< " (" << script_file << ")" << std::endl;
+		FeLog() << "Error, file not found: " << path << script_file << std::endl;
 	}
 }
 

--- a/src/scraper_general.cpp
+++ b/src/scraper_general.cpp
@@ -74,7 +74,7 @@ void write_romlist( const std::string &filename,
 		// one line header showing what the columns represent
 		//
 		outfile << "#" << FeRomInfo::indexStrings[i++];
-		while ( i < FeRomInfo::Favourite )
+		while ( i < FeRomInfo::LAST_INFO )
 			outfile << ";" << FeRomInfo::indexStrings[i++];
 		outfile << std::endl;
 


### PR DESCRIPTION
- Add cache checks for filter config, tags, favs, and file mod times
- Remove invalidation from save callbacks
- Refactor `fe_romlist`, split monoliths, add helpers, add comments
- Update Tag & Fav file format to `rom;emu`, enables mixed romlist duplicate name tagging (backwards compatible)
- Update Tags to attach to duplicate roms, rather than just the first found match
- Update Tags to exclude duplicate entries
- Update cache to store only romlist info, not tag/fav/stat/avail
- Fix clone group regression where, master is now the default group item again