### PR TITLE
Add Shuffle Sort

### DIFF
--- a/src/fe_info.cpp
+++ b/src/fe_info.cpp
@@ -68,6 +68,7 @@ const char *FeRomInfo::indexStrings[] =
 	"PlayedCount",
 	"PlayedTime",
 	"FileIsAvailable",
+	"Shuffle",
 	NULL
 };
 
@@ -95,7 +96,8 @@ const bool FeRomInfo::isNumeric( Index index )
 {
 	return ( index == FeRomInfo::Players )
 		|| ( index == FeRomInfo::PlayedCount )
-		|| ( index == FeRomInfo::PlayedTime );
+		|| ( index == FeRomInfo::PlayedTime )
+		|| ( index == FeRomInfo::Shuffle );
 }
 
 // Returns true if FeRomInfo Index is a Stat

--- a/src/fe_info.hpp
+++ b/src/fe_info.hpp
@@ -69,6 +69,7 @@ public:
 		PlayedCount,
 		PlayedTime,
 		FileIsAvailable,
+		Shuffle,
 		LAST_INDEX
 	};
 

--- a/src/fe_romlist.cpp
+++ b/src/fe_romlist.cpp
@@ -28,6 +28,8 @@
 #include <iostream>
 #include "nowide/fstream.hpp"
 #include <algorithm>
+#include <numeric>
+#include <random>
 
 #include <squirrel.h>
 #include <sqstdstring.h>
@@ -353,6 +355,20 @@ void FeRomList::load_tag_data(
 }
 
 //
+// Add shuffle data to romlist for randomized sorting
+//
+void FeRomList::load_shuffle_data()
+{
+	std::mt19937 rnd{ std::random_device{}() };
+	std::vector<int> shuffle( m_list.size() );
+	std::iota( shuffle.begin(), shuffle.end(), 0 );
+	std::shuffle( shuffle.begin(), shuffle.end(), rnd );
+	int i = 0;
+	for ( FeRomInfoListType::iterator it=m_list.begin(); it!=m_list.end(); ++it )
+		(*it).set_info( FeRomInfo::Shuffle, as_str( shuffle[i++] ) );
+}
+
+//
 // Add given rom tags to the extra lists for saving
 // - Called when rom is filtered from list
 //
@@ -443,6 +459,7 @@ bool FeRomList::load_romlist(
 
 	bool test_available = display.test_for_targets({ FeRomInfo::FileIsAvailable });
 	bool test_stats = display.test_for_targets( FeRomInfo::Stats );
+	bool test_shuffle = display.test_for_targets({ FeRomInfo::Shuffle });
 	std::map<std::string, std::vector<std::string>> emu_roms;
 
 	FeCache::clear_stats();
@@ -458,6 +475,7 @@ bool FeRomList::load_romlist(
 	load_tag_data( rom_map );
 	if ( test_available ) get_file_availability( emu_roms );
 	if ( test_stats ) get_played_stats();
+	if ( test_shuffle ) load_shuffle_data();
 
 	if ( !(response & RomlistResponse::Loaded_Global) )
 		response |= apply_global_filter( display );

--- a/src/fe_romlist.hpp
+++ b/src/fe_romlist.hpp
@@ -210,6 +210,7 @@ private:
 	int load_romlist_data( FeDisplayInfo &display );
 	void load_fav_data( std::map<std::string, std::vector<FeRomInfo*>> &rom_map );
 	void load_tag_data( std::map<std::string, std::vector<FeRomInfo*>> &rom_map );
+	void load_shuffle_data();
 	int apply_global_filter( FeDisplayInfo &display );
 	void store_extra_tags( FeRomInfo &rom );
 


### PR DESCRIPTION
- Add `Shuffle` option for filter sorting

Lists sorted with `Shuffle` will be displayed in a random order every time the Display is loaded.
Unfortunately this will also disable caching for that list, since it changes every load.

Example usage: A Filter that shows a random selection of un-played games:
- Rule: PlayedCount equals 0
- Limit: 10
- Sort: Shuffle