### PR TITLE
Add Reverse Order Filter Option

### DIFF
--- a/config/language/en.msg
+++ b/config/language/en.msg
@@ -112,6 +112,7 @@ _help_filter_list_limit;Set this to a non-zero value if you wish to limit the si
 _help_filter_name;The name for this filter
 _help_filter_rule;Configure this filter rule.  A game must match all filter rules (or a single exception) to be listed in a filter
 _help_filter_sort_by;The game information attribute that you wish to sort the collection/rom list by.  Set to "No Sort" to keep the ordering from the source collection/rom list
+_help_filter_reverse_order;Reverse the order of the sorted collection/rom list.  Default order is "A to Z" for info, "Largest to Smallest" for stats, or the source list order for "No Sort"
 _help_filter_wrap_mode;Set what happens when the "Next Filter" or "Previous Filter" actions reach the end of the filter set
 _help_font_path;The directories containing fonts.  Multiple directories can be entered if separated by a semicolon.  Attract-Mode will recursively search these directories to find a specified font
 _help_game_custom_args;Set this to override the default command line arguments for this game.  Set this to [nothing] if you want to override with no parameters.  The following get substituted appropriately: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn]

--- a/config/language/msg_template.txt
+++ b/config/language/msg_template.txt
@@ -371,6 +371,7 @@ _help_filter_list_limit;Set this to a non-zero value if you wish to limit the si
 _help_filter_name;The name for this filter
 _help_filter_rule;Configure this filter rule.  A game must match all filter rules (or a single exception) to be listed in a filter
 _help_filter_sort_by;The game information attribute that you wish to sort the collection/rom list by.  Set to "No Sort" to keep the ordering from the source collection/rom list
+_help_filter_reverse_order;Reverse the order of the sorted collection/rom list.  Default order is "A to Z" for info, "Largest to Smallest" for stats, or the source list order for "No Sort"
 _help_filter_wrap_mode;Set what happens when the "Next Filter" or "Previous Filter" actions reach the end of the filter set
 _help_font_path;The directories containing fonts.  Multiple directories can be entered if separated by a semicolon.  Attract-Mode will recursively search these directories to find a specified font
 _help_game_custom_args;Set this to override the default command line arguments for this game.  Set this to [nothing] if you want to override with no parameters.  The following get substituted appropriately: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn]


### PR DESCRIPTION
- Add Reverse Option to Filter settings

This is NOT exactly an Ascending/Descending toggle, since legacy behavior automatically switched to Descending for stats.
Since this auto-switching is now removed, the "reverse" option behaves as follows:

Reverse `OFF` (default):
- A-Z for info
- Large-Small for Stats
- Romlist order for NoSort

Reverse `ON`:
- Sort Z-A for info
- Small-Large for Stats
- Reverse Romlist order for NoSort