### PR TITLE
Fix Listbox Magic Strings

### DIFF
--- a/src/fe_listbox.cpp
+++ b/src/fe_listbox.cpp
@@ -26,6 +26,7 @@
 #include "fe_present.hpp"
 #include "fe_util.hpp"
 #include <iostream>
+#include <algorithm>
 
 const std::string DEFAULT_FORMAT_STRING = "[Title]";
 
@@ -383,7 +384,7 @@ void FeListBox::internalSetText( const int index )
 			FePresent::script_process_magic_strings(
 				text_string,
 				m_filter_offset,
-				listentry - m_display_rom_index
+				i - m_selected_row
 			);
 			m_feSettings->do_text_substitutions_absolute(
 				text_string,
@@ -428,9 +429,11 @@ void FeListBox::on_new_list( FeSettings *s )
 	m_display_rom_index = s->get_rom_index( m_display_filter_index, 0 );
 
 	// Calculate the initial position for Moving mode
-	if ( m_mode == Moving && m_display_filter_size > m_texts.size() )
+	// - Maintains the current m_selected_row if possible
+	// - Required since fav/tag changes trigger new_list which shouldn't move the list
+	if ( m_mode == Moving )
 	{
-		m_list_start_offset = std::max( 0, std::min( m_display_rom_index - (int)m_texts.size() / 2, m_display_filter_size - (int)m_texts.size() ));
+		m_list_start_offset = std::clamp( m_display_rom_index - m_selected_row, 0, std::max( 0, m_display_filter_size - (int)m_texts.size() ) );
 		m_selected_row = m_display_rom_index - m_list_start_offset;
 	}
 


### PR DESCRIPTION
- Fixed magic string index
- Updated "Moving" sel_mode to maintain previous selected_row

Regression in https://github.com/oomek/attractplus/commit/ecff21fa954eb7cbf1c2da08c91ed45c24cc990d caused custom magictoken function indexes to mismatch.

Plus an issue found in https://github.com/oomek/attractplus/commit/6da603f1d349d078ee1e9a5ffcf968ec7554b524. Toggling Fav/Tag triggers `on_new_list`, which reverts the selection position to middle.

Test layout:

```squirrel
local flw = fe.layout.width
local flh = fe.layout.height

function myFavourite(index_offset) {
    return "(" + index_offset + ") " + fe.game_info(Info.Favourite, index_offset);
}

local list = fe.add_listbox(0, 0, flw, flh)
list.format_string = "[Title] - [!myFavourite] = [Favourite]"
list.char_size = flh / list.rows / 2
list.align = Align.MiddleLeft
list.sel_mode = Selection.Moving
```

- Compare [420](https://github.com/oomek/attractplus/actions/runs/15911139792) with [433](https://github.com/oomek/attractplus/actions/runs/15944753420)
- Mark a game as Fav
- 420 will mismatch Fav value when scrolled
- 420 will revert selection to center when Fav'd