### PR TITLE
Add PlayedLast Stat

### DIFF
--- a/src/fe_config.cpp
+++ b/src/fe_config.cpp
@@ -2306,6 +2306,7 @@ void FeEditGameMenu::get_options( FeConfigContext &ctx )
 
 		case FeRomInfo::PlayedCount:
 		case FeRomInfo::PlayedTime:
+		case FeRomInfo::PlayedLast:
 			type = Opt::EDIT;
 			opaque = 3;
 			break;
@@ -2374,7 +2375,7 @@ bool FeEditGameMenu::on_option_select( FeConfigContext &ctx, FeBaseConfigMenu *&
 		ctx.tags_dialog();
 		break;
 
-	case 3: // PlayedCount, PlayedTime
+	case 3: // PlayedCount, PlayedTime, PlayedLast
 		m_update_stats = true;
 		break;
 

--- a/src/fe_info.cpp
+++ b/src/fe_info.cpp
@@ -24,8 +24,10 @@
 #include "fe_util.hpp"
 #include "fe_util_sq.hpp"
 #include "fe_cache.hpp"
+#include <algorithm>
 #include <iostream>
 #include <sstream>
+#include <ctime>
 
 #include <iomanip>
 
@@ -67,14 +69,35 @@ const char *FeRomInfo::indexStrings[] =
 	"Tags",
 	"PlayedCount",
 	"PlayedTime",
+	"PlayedLast",
 	"FileIsAvailable",
 	"Shuffle",
 	NULL
 };
 
-const std::set<FeRomInfo::Index> FeRomInfo::Stats = {
+const char *FeRomInfo::specialStrings[] =
+{
+	"DisplayName",
+	"ListTitle",
+	"FilterName",
+	"ListFilterName",
+	"ListSize",
+	"ListEntry",
+	"Search",
+	"TitleFull",
+	"SortName",
+	"SortValue",
+	"System",
+	"SystemN",
+	"Overview",
+	NULL
+};
+
+// Stats are list in the order they appear in the .stat file
+const std::vector<FeRomInfo::Index> FeRomInfo::Stats = {
 	FeRomInfo::PlayedCount,
-	FeRomInfo::PlayedTime
+	FeRomInfo::PlayedTime,
+	FeRomInfo::PlayedLast
 };
 
 FeRomInfo::FeRomInfo()
@@ -97,13 +120,14 @@ const bool FeRomInfo::isNumeric( Index index )
 	return ( index == FeRomInfo::Players )
 		|| ( index == FeRomInfo::PlayedCount )
 		|| ( index == FeRomInfo::PlayedTime )
+		|| ( index == FeRomInfo::PlayedLast )
 		|| ( index == FeRomInfo::Shuffle );
 }
 
 // Returns true if FeRomInfo Index is a Stat
 const bool FeRomInfo::isStat( Index index )
 {
-	return Stats.find( index ) != Stats.end();
+	return std::find( Stats.begin(), Stats.end(), index ) != Stats.end();
 }
 
 const std::string &FeRomInfo::get_info( int i ) const
@@ -221,6 +245,7 @@ void FeRomInfo::load_stats(
 
 	m_info[PlayedCount] = "0";
 	m_info[PlayedTime] = "0";
+	m_info[PlayedLast] = "0";
 
 	if ( path.empty() )
 		return;
@@ -230,18 +255,17 @@ void FeRomInfo::load_stats(
 	if ( !myfile.is_open() )
 		return;
 
-	std::string line;
-	if ( myfile.good() )
-	{
-		getline( myfile, line );
-		m_info[PlayedCount] = line;
-	}
+	std::string played_count;
+	std::string played_time;
+	std::string played_last;
 
-	if ( myfile.good() )
-	{
-		getline( myfile, line );
-		m_info[PlayedTime] = line;
-	}
+	if ( myfile.good() ) getline( myfile, played_count );
+	if ( myfile.good() ) getline( myfile, played_time );
+	if ( myfile.good() ) getline( myfile, played_last );
+
+	m_info[PlayedCount] = played_count.empty() ? "0" : played_count;
+	m_info[PlayedTime] = played_time.empty() ? "0" : played_time;
+	m_info[PlayedLast] = played_last.empty() ? "0" : played_last;
 
 	myfile.close();
 }
@@ -252,9 +276,11 @@ void FeRomInfo::update_stats( const std::string &path, int count_incr, int playe
 
 	int new_count = as_int( m_info[PlayedCount] ) + count_incr;
 	int new_time = as_int( m_info[PlayedTime] ) + played_incr;
+	int new_last = std::time(0);
 
 	m_info[PlayedCount] = as_str( new_count );
 	m_info[PlayedTime] = as_str( new_time );
+	m_info[PlayedLast] = as_str( new_last );
 
 	// Save stats to cache, and continue to save original stat file as well
 	FeCache::set_stats_info( path, m_info );
@@ -270,7 +296,9 @@ void FeRomInfo::update_stats( const std::string &path, int count_incr, int playe
 		return;
 	}
 
-	myfile << m_info[PlayedCount] << std::endl << m_info[PlayedTime] << std::endl;
+	myfile << m_info[PlayedCount] << std::endl
+		<< m_info[PlayedTime] << std::endl
+		<< m_info[PlayedLast] << std::endl;
 	myfile.close();
 }
 

--- a/src/fe_info.hpp
+++ b/src/fe_info.hpp
@@ -68,9 +68,28 @@ public:
 		Tags,
 		PlayedCount,
 		PlayedTime,
+		PlayedLast,
 		FileIsAvailable,
 		Shuffle,
 		LAST_INDEX
+	};
+
+	enum Special
+	{
+		DisplayName = 0,
+		ListTitle, // Deprecated as of 1.5
+		FilterName,
+		ListFilterName, // Deprecated as of 1.5
+		ListSize,
+		ListEntry,
+		Search,
+		TitleFull,
+		SortName,
+		SortValue,
+		System,
+		SystemN,
+		Overview,
+		LAST_SPECIAL
 	};
 
 	// Certain indices gets repurposed during -listsoftware
@@ -80,8 +99,9 @@ public:
 	static const Index LAST_INFO = Favourite; // Everything prior to Favourite is loaded from romlist
 
 	static const char *indexStrings[];
+	static const char *specialStrings[];
 
-	static const std::set<FeRomInfo::Index> Stats; // Set of indexes used for Stats
+	static const std::vector<FeRomInfo::Index> Stats; // List of indexes used for Stats
 	static const bool isNumeric( Index index ); // Returns true if FeRomInfo Index value should be considered numeric for sorting
 	static const bool isStat( Index index ); // Returns true if FeRomInfo Index is a Stat
 

--- a/src/fe_romlist.cpp
+++ b/src/fe_romlist.cpp
@@ -458,7 +458,7 @@ bool FeRomList::load_romlist(
 	sf::Clock load_timer;
 
 	bool test_available = display.test_for_targets({ FeRomInfo::FileIsAvailable });
-	bool test_stats = display.test_for_targets( FeRomInfo::Stats );
+	bool test_stats = display.test_for_targets( std::set<FeRomInfo::Index>( FeRomInfo::Stats.begin(), FeRomInfo::Stats.end() ) );
 	bool test_shuffle = display.test_for_targets({ FeRomInfo::Shuffle });
 	std::map<std::string, std::vector<std::string>> emu_roms;
 

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -37,6 +37,7 @@
 #include <random>
 #include <stdlib.h>
 #include <cctype>
+#include <ctime>
 
 #include <SFML/System/Clock.hpp>
 #include <SFML/Config.hpp>
@@ -672,7 +673,7 @@ void FeSettings::init_display()
 	if ( m_current_display < 0 )
 	{
 		m_rl.init_as_empty_list();
-		FeRomInfoListType &l = m_rl.get_list();
+		FeRomInfoListType &rl = m_rl.get_list();
 
 
 		for ( unsigned int i=0; i<m_display_menu.size(); i++ )
@@ -683,7 +684,7 @@ void FeSettings::init_display()
 			rom.set_info( FeRomInfo::Title, p->get_info( FeDisplayInfo::Name ) );
 			rom.set_info( FeRomInfo::Emulator, "@" );
 
-			l.push_back( rom );
+			rl.push_back( rom );
 		}
 
 		if ( m_displays_menu_exit )
@@ -696,7 +697,7 @@ void FeSettings::init_display()
 			rom.set_info( FeRomInfo::Emulator, "@exit" );
 			rom.set_info( FeRomInfo::AltRomname, "exit" );
 
-			l.push_back( rom );
+			rl.push_back( rom );
 		}
 
 		FeDisplayInfo empty( "" );
@@ -2463,7 +2464,7 @@ bool FeSettings::update_stats( int play_count, int play_time )
 
 	rom->update_stats( path, play_count, play_time );
 
-	bool fixed = m_rl.fix_filters( m_displays[m_current_display], FeRomInfo::Stats );
+	bool fixed = m_rl.fix_filters( m_displays[m_current_display], std::set<FeRomInfo::Index>( FeRomInfo::Stats.begin(), FeRomInfo::Stats.end() ) );
 
 	if ( fixed && ( &m_rl.lookup( filter_index, rom_index ) != rom ))
 	{
@@ -2511,251 +2512,182 @@ void FeSettings::get_exit_question( std::string &exit_question ) const
 		exit_question = m_exit_question;
 }
 
+//
+// Perform substitutions of the [MagicString] sequences occurring in str
+//
 void FeSettings::do_text_substitutions( std::string &str, int filter_offset, int index_offset )
 {
 	int filter_index = get_filter_index_from_offset( filter_offset );
-	do_text_substitutions_absolute(
-				str,
-				filter_index,
-				get_rom_index( filter_index, index_offset ) );
+	int rom_index = get_rom_index( filter_index, index_offset );
+	do_text_substitutions_absolute( str, filter_index, rom_index );
 }
 
+//
+// Perform substitutions of the [MagicString] sequences occurring in str
+//
 void FeSettings::do_text_substitutions_absolute( std::string &str, int filter_index, int rom_index )
 {
-	//
-	// Perform substitutions of the [XXX] sequences occurring in str
-	//
-	size_t pos = str.find( "[" );
+	size_t pos = str.find( '[' );
 	while ( pos != std::string::npos )
 	{
 		size_t close = str.find_first_of( ']', pos+1 );
-
 		if ( close == std::string::npos )
 			break; // done, no more enclosed tokens
 
 		std::string token = str.substr( pos+1, close-pos-1 );
-		bool matched=false;
-
-		//
-		// First check for rom info attribute matches
-		//
-		for ( int i=0; i<FeRomInfo::LAST_INDEX; i++ )
-		{
-			// these are special cases dealt with elsewhere
-			if (( i == FeRomInfo::Title )
-					|| ( i == FeRomInfo::PlayedTime ))
-				continue;
-
-			if ( token.compare( FeRomInfo::indexStrings[i] ) == 0 )
-			{
-				const std::string &rep = get_rom_info_absolute(
-						filter_index,
-						rom_index,
-						(FeRomInfo::Index)i );
-
-				str.replace( pos, close-pos+1, rep );
-				pos += rep.size();
-				matched=true;
-			}
-		}
-
-		if ( matched )
-		{
-			pos = str.find( "[", pos );
-			continue;
-		}
-
-		//
-		// Next check for various special case attributes
-		//
-		const char *tokenStrings[] =
-		{
-			"DisplayName",
-			"ListTitle", // deprecated as of 1.5
-			"FilterName",
-			"ListFilterName", // deprecated as of 1.5
-			"ListSize",
-			"ListEntry",
-			"Search",
-			FeRomInfo::indexStrings[FeRomInfo::Title],
-			"TitleFull",
-			FeRomInfo::indexStrings[FeRomInfo::PlayedTime],
-			"SortName",
-			"SortValue",
-			"System",
-			"SystemN",
-			"Overview",
-			NULL
-		};
-
-		int i=0;
-		while ( tokenStrings[i] != NULL )
-		{
-			if ( token.compare( tokenStrings[i] ) == 0 )
-			{
-				matched = true;
-				break;
-			}
-
-			i++;
-		}
-
-		if ( !matched )
-		{
-			pos = str.find( "[", pos+1 );
-			continue;
-		}
-
 		std::string rep;
-		switch ( i )
+
+		if ( get_token_value( token, filter_index, rom_index, rep ) )
 		{
-		case 0: // "DisplayName"
-		case 1: // "ListTitle" // deprecated as of 1.5
-			rep = get_current_display_title();
-			break;
-
-		case 2:	// "FilterName"
-		case 3: // "ListFilterName" // deprecated as of 1.5
-			rep = get_filter_name( filter_index );
-			break;
-
-		case 4: // "ListSize"
-			rep = as_str( get_filter_size( filter_index ) );
-			break;
-
-		case 5: // "ListEntry"
-			rep = as_str( rom_index + 1 );
-			break;
-
-		case 6: // "Search"
-			rep = m_current_search_str;
-			break;
-
-		case 7: // "Title"
-		case 8: // "TitleFull"
-			rep = get_rom_info_absolute( filter_index,
-				rom_index, FeRomInfo::Title );
-			if (( m_hide_brackets ) && ( i == 7 )) // 7 == Title
-			{
-				// Don't strip brackets when showing a clones group
-				if ( m_clone_index < 0 )
-					rep = name_with_brackets_stripped( rep );
-			}
-			break;
-
-		case 9: // "PlayedTime"
-			rep = get_played_display_string( filter_index, rom_index );
-			break;
-
-		case 10: // "SortName"
-		case 11: // "SortValue"
-			{
-				FeRomInfo::Index sort_by;
-				bool reverse_sort;
-				int list_limit;
-				std::string sort_name;
-
-				get_current_sort( sort_by, reverse_sort, list_limit );
-
-				if ( sort_by == FeRomInfo::LAST_INDEX )
-				{
-					get_translation( "None", sort_name );
-					sort_by = FeRomInfo::Title;
-				}
-				else
-					get_translation( FeRomInfo::indexStrings[sort_by], sort_name );
-
-
-				if ( i == 10 ) // SortName
-				{
-					rep = sort_name;
-				}
-				else
-				{
-					if ( sort_by == FeRomInfo::PlayedTime )
-						rep = get_played_display_string(
-							filter_index,
-							rom_index );
-					else
-						rep = get_rom_info_absolute(
-							filter_index,
-							rom_index, sort_by );
-				}
-			}
-			break;
-
-		case 12: // "System"
-		case 13: // "SystemN"
-			{
-				const std::string &en
-					= get_rom_info_absolute(
-						filter_index,
-						rom_index,
-						FeRomInfo::Emulator );
-
-				const FeEmulatorInfo *emu = get_emulator( en );
-				if ( emu )
-				{
-					const std::vector< std::string > &ss =
-						emu->get_systems();
-
-					if ( !ss.empty() )
-					{
-						rep = ( i == 12 )
-							? ss.front()
-							: ss.back();
-					}
-				}
-			}
-			break;
-
-		case 14: // "Overview"
-			get_game_overview_absolute( filter_index, rom_index, rep );
-			break;
-
-		default:
-			ASSERT( 0 ); // unhandled token
-			break;
+			str.replace( pos, close-pos+1, rep );
+			pos += rep.size();
 		}
 
-		str.replace( pos, close-pos+1, rep );
-		pos = str.find( "[", pos+rep.size() );
+		pos = str.find( '[', pos+1 );
 	}
 }
 
-std::string FeSettings::get_played_display_string( int filter_index, int rom_index )
+//
+// Populate value with the given magic token result
+// - Returns false if the given token is invalid
+//
+bool FeSettings::get_token_value( std::string &token, int filter_index, int rom_index, std::string &value )
 {
+	int i = get_token_index( FeRomInfo::indexStrings, token );
+	switch ( i )
+	{
+		case FeRomInfo::Title:
+			// Don't strip brackets when showing a clones group
+			value = get_rom_info_absolute( filter_index, rom_index, FeRomInfo::Title );
+			if ( m_hide_brackets && m_clone_index < 0 ) value = name_with_brackets_stripped( value );
+			return true;
+		case FeRomInfo::PlayedTime:
+			value = get_played_time_display_string( filter_index, rom_index );
+			return true;
+		case FeRomInfo::PlayedLast:
+			value = get_played_last_display_string( filter_index, rom_index );
+			return true;
+		default:
+			value = get_rom_info_absolute( filter_index, rom_index, (FeRomInfo::Index)i );
+			return true;
+		case -1:
+			return get_special_token_value( token, filter_index, rom_index, value );
+	}
+}
+
+//
+// Special attributes
+//
+bool FeSettings::get_special_token_value( std::string &token, int filter_index, int rom_index, std::string &value )
+{
+	int i = get_token_index( FeRomInfo::specialStrings, token );
+	switch ( i )
+	{
+		case FeRomInfo::DisplayName:
+		case FeRomInfo::ListTitle:
+			value = get_current_display_title();
+			return true;
+		case FeRomInfo::FilterName:
+		case FeRomInfo::ListFilterName:
+			value = get_filter_name( filter_index );
+			return true;
+		case FeRomInfo::ListSize:
+			value = as_str( get_filter_size( filter_index ) );
+			return true;
+		case FeRomInfo::ListEntry:
+			value = as_str( rom_index + 1 );
+			return true;
+		case FeRomInfo::Search:
+			value = m_current_search_str;
+			return true;
+		case FeRomInfo::TitleFull:
+			value = get_rom_info_absolute( filter_index, rom_index, FeRomInfo::Title );
+			return true;
+		case FeRomInfo::SortName:
+		{
+			FeRomInfo::Index sort_by;
+			bool reverse_sort;
+			int list_limit;
+			get_current_sort( sort_by, reverse_sort, list_limit );
+			std::string sort_token = ( sort_by == FeRomInfo::LAST_INDEX ) ? "None" : FeRomInfo::indexStrings[sort_by];
+			get_translation( sort_token, value );
+			return true;
+		}
+		case FeRomInfo::SortValue:
+		{
+			FeRomInfo::Index sort_by;
+			bool reverse_sort;
+			int list_limit;
+			get_current_sort( sort_by, reverse_sort, list_limit );
+			std::string sort_token = FeRomInfo::indexStrings[ ( sort_by == FeRomInfo::LAST_INDEX ) ? FeRomInfo::Title : sort_by ];
+			return get_token_value( sort_token, filter_index, rom_index, value );
+		}
+		case FeRomInfo::System:
+		case FeRomInfo::SystemN:
+		{
+			value = "";
+			const std::string &emu_name = get_rom_info_absolute( filter_index, rom_index, FeRomInfo::Emulator );
+			const FeEmulatorInfo *emu = get_emulator( emu_name );
+			if ( emu ) {
+				const std::vector<std::string> &systems = emu->get_systems();
+				if ( !systems.empty() ) value = ( i == FeRomInfo::SystemN ) ? systems.back() : systems.front();
+			}
+			return true;
+		}
+		case FeRomInfo::Overview:
+			value = get_game_overview_absolute( filter_index, rom_index, value );
+			return true;
+		default:
+			return false;
+	}
+}
+
+const float SECONDS_IN_MINUTE = 60;
+const float SECONDS_IN_HOUR = 3600;
+const float SECONDS_IN_DAY = 86400;
+
+//
+// Format played time to #.# Minutes, Hours, or Days
+//
+std::string FeSettings::get_played_time_display_string( int filter_index, int rom_index )
+{
+	int seconds = as_int( get_rom_info_absolute( filter_index, rom_index, FeRomInfo::PlayedTime ) );
+	float num;
 	std::string label;
 
-	int raw = as_int(
-		get_rom_info_absolute( filter_index,
-			rom_index,
-			FeRomInfo::PlayedTime ) );
-
-	float num;
-
-	if ( raw < 3600 )
+	if ( seconds < SECONDS_IN_HOUR )
 	{
-		num = raw / 60.f;
-		label = "Minutes";
+		num = seconds / SECONDS_IN_MINUTE;
+		label = "$1 Minutes";
 	}
-	else if ( raw < 86400 )
+	else if ( seconds < SECONDS_IN_DAY )
 	{
-		num = raw / 3600.f;
-		label = "Hours";
+		num = seconds / SECONDS_IN_HOUR;
+		label = "$1 Hours";
 	}
 	else
 	{
-		num = raw / 86400.f;
-		label = "Days";
+		num = seconds / SECONDS_IN_DAY;
+		label = "$1 Days";
 	}
 
-	std::string op_label;
-	get_translation( label, op_label );
-
-	return as_str( num, 1 ) + " " + op_label;
+	label = get_translation( label );
+	perform_substitution( label, { as_str( num, 1 ) });
+	return label;
 }
 
+std::string FeSettings::get_played_last_display_string( int filter_index, int rom_index )
+{
+	std::string value = get_rom_info_absolute( filter_index, rom_index, FeRomInfo::PlayedLast );
+	std::time_t timestamp = static_cast<std::time_t>( as_int( value ) );
+
+	if ( timestamp == 0 )
+		return get_translation( "Never" );
+
+	char label[128]; // buffer large enough to fit formatted timestamp
+	std::strftime( std::data(label), std::size(label), "%Y-%m-%d %H:%M:%S", std::localtime( &timestamp ) );
+	return label;
+}
 
 FeEmulatorInfo *FeSettings::get_emulator( const std::string &n )
 {

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -289,7 +289,8 @@ private:
 
 	void internal_load_language( const std::string &lang );
 
-	std::string get_played_display_string( int filter_index, int rom_index );
+	std::string get_played_time_display_string( int filter_index, int rom_index );
+	std::string get_played_last_display_string( int filter_index, int rom_index );
 
 	bool internal_get_best_artwork_file(
 		const FeRomInfo &rom,
@@ -429,6 +430,8 @@ public:
 
 	void do_text_substitutions( std::string &str, int filter_offset, int index_offset );
 	void do_text_substitutions_absolute( std::string &str, int filter_index, int rom_index );
+	bool get_token_value( std::string &token, int filter_index, int rom_index, std::string &value );
+	bool get_special_token_value( std::string &token, int filter_index, int rom_index, std::string &value );
 
 	void get_current_sort( FeRomInfo::Index &idx, bool &rev, int &limit );
 

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -1965,3 +1965,14 @@ bool hex_to_color( std::string hex, sf::Color &dest_color )
 		return false;
 	}
 }
+
+int get_token_index( const char *tokens[], std::string &token )
+{
+	int i = 0;
+	while ( tokens[i] != NULL )
+	{
+		if ( token.compare( tokens[i] ) == 0 ) return i;
+		i++;
+	}
+	return -1;
+}

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -399,3 +399,8 @@ void hide_console();
 // - Returns true on success
 //
 bool hex_to_color( std::string hex, sf::Color &dest_color );
+
+//
+// Return index of token in tokens, or -1 if not found
+//
+int get_token_index( const char *tokens[], std::string &token );

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1668,6 +1668,9 @@ void FePresent::script_process_magic_strings( std::string &str,
 			FeLog() << "Script Error in magic string function: "
 				<< magic << " - "
 				<< e.Message() << std::endl;
+
+			// Skip the magic token that's causing an error to avoid throwing an exception
+			pos += TOK_LEN;
 		}
 
 		pos = str.find( TOK, pos );


### PR DESCRIPTION
`PlayedLast` timestamp added to rom stat file when played.

```squirrel
local minute = 60 // seconds
local hour = 60 * minute
local day = 24 * hour
local month = 30 * day
local year = 365 * day

function myPlayedLast(index_offset) {
    local p = fe.game_info(Info.PlayedLast, index_offset).tointeger()
    if (!p) return "Never"
    local pl = @(n, unit) format("%d %s%s ago", ceil(n), unit, ceil(n) == 1 ? "" : "s")
    local seconds = (time() - p).tofloat()
    if (seconds < minute) return "A moment ago"
    if (seconds < hour) return pl(seconds / minute, "minute")
    if (seconds < day) return pl(seconds / hour, "hour")
    if (seconds < month) return pl(seconds / day, "day")
    if (seconds < year) return pl(seconds / month, "month")
    return pl(seconds / year, "year")
}

local flw = fe.layout.width
local flh = fe.layout.height
local list = fe.add_listbox(0, 0, flw, flh)
list.format_string = "[Title] - [!myPlayedLast] ([PlayedLast])"
list.char_size = flh / list.rows / 2
list.align = Align.MiddleLeft
```
![image](https://github.com/user-attachments/assets/ce25433d-e2fc-4ac1-8385-9fbba63f5dda)

