### PR TITLE
Fix parsing quotes in emulator config

### DIFF
--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -2430,6 +2430,7 @@ void FeSettings::prep_for_launch( std::string &command,
 	}
 
 	do_text_substitutions_absolute( args, filter_index, rom_index );
+	args = fix_quotes( args );
 
 	std::string temp = get_game_extra( Executable );
 	if ( temp.empty() )
@@ -2437,7 +2438,7 @@ void FeSettings::prep_for_launch( std::string &command,
 
 	command = clean_path( temp );
 
-	work_dir = clean_path( emu->get_info( FeEmulatorInfo::Working_dir ), true );
+	work_dir = clean_path( strip_quotes( emu->get_info( FeEmulatorInfo::Working_dir )), true );
 	if ( work_dir.empty() )
 	{
 		size_t pos = command.find_last_of( "/\\" );

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -794,6 +794,34 @@ int perform_substitution(
 	return count;
 }
 
+std::string strip_quotes( const std::string &str )
+{
+	if ( str.size() >= 2 && str.front() == '"' && str.back() == '"' )
+		return str.substr( 1, str.size() - 2 );
+
+	return str;
+}
+
+std::string fix_quotes( const std::string &str )
+{
+	if ( str.empty() )
+		return str;
+
+	// Remove all quotes from the string
+	std::string clean_str;
+	for ( char c : str )
+	{
+		if ( c != '"' )
+			clean_str += c;
+	}
+
+	// If the clean string contains spaces, wrap it with quotes
+	if ( clean_str.find( ' ' ) != std::string::npos )
+		return "\"" + clean_str + "\"";
+
+	return clean_str;
+}
+
 std::string get_available_filename(
 			const std::string &path,
 			const std::string &base,

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -69,6 +69,16 @@ int perform_substitution(
 );
 
 //
+// Strip surrounding quotes from a string
+//
+std::string strip_quotes( const std::string &str );
+
+//
+// Remove all quotes from inside a string and wrap with quotes if it contains spaces
+//
+std::string fix_quotes( const std::string &str );
+
+//
 //
 std::string name_with_brackets_stripped( const std::string &name );
 


### PR DESCRIPTION
emulator.cfg should be now agnostic to whether paths are in quotes or not
```
args                    [romfilename]
workdir                 D:/EMU/MAME
rompath                 D:/Downloads/MAME ROMs (split)

args                    [rompath][name][romext]
workdir                 D:/EMU/MAME
rompath                 D:/Downloads/MAME ROMs (split)

args                    "[romfilename]"
workdir                 "D:/EMU/MAME"
rompath                 "D:/Downloads/MAME ROMs (split)"
```