### PR TITLE
Fix Startup Modes

### DIFF
--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -839,7 +839,7 @@ void FeSettings::load_state()
 
 		int i=0;
 		size_t pos2=0;
-		while (( pos2 < tok.size() ) && ( i < 3 ))
+		while ( pos2 < tok.size() )
 		{
 			std::string tok2;
 			token_helper( tok, pos2, tok2, "," );
@@ -2008,11 +2008,14 @@ void FeSettings::step_current_selection( int step )
 	set_current_selection( filter_index, get_rom_index( filter_index, step )  );
 }
 
-bool FeSettings::select_last_launch()
+bool FeSettings::select_last_launch( bool initial_load )
 {
 	bool retval = false;
-	if (( m_current_display != m_last_launch_display )
-		&& ( m_last_launch_display < (int)m_displays.size() ))
+
+	// On initial_load m_current_display is set *before* the display is actually loaded
+	// - switch_to_clone_group requires the romlist, which is loaded by set_display
+	if (( initial_load || ( m_current_display != m_last_launch_display )) &&
+		( m_last_launch_display < (int)m_displays.size() ))
 	{
 		set_display( m_last_launch_display );
 		retval = true;

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -404,7 +404,7 @@ public:
 	bool switch_from_clone_group();
 	int get_clone_index();
 
-	bool select_last_launch();
+	bool select_last_launch( bool initial_load = false );
 	bool is_last_launch( int filter_offset, int index_offset );
 	int get_joy_thresh() const { return m_joy_thresh; }
 	void init_mouse_capture( sf::RenderWindow *window );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
 {
 	std::string config_path, log_file;
 	bool launch_game = false;
-	bool first_intro = true;
+	bool initial_load = true;
 	bool process_console = false;
 	int last_display_index = -1;
 	FeLogLevel log_level = FeLog_Info;
@@ -325,7 +325,7 @@ int main(int argc, char *argv[])
 
 #ifdef USE_DRM
 				feSettings.switch_from_clone_group();
-				feVM.load_layout(true);
+				feVM.load_layout();
 #else
 				if ( feSettings.switch_from_clone_group() )
 					feVM.update_to_new_list( 0, true );
@@ -550,7 +550,6 @@ int main(int argc, char *argv[])
 				move_state = FeInputMap::LAST_COMMAND;
 				move_triggered = FeInputMap::LAST_COMMAND;
 				move_last_triggered = 0;
-				first_intro = false;
 				redraw = true;
 				c = FeInputMap::LAST_COMMAND;
 				bool has_layout = false;
@@ -559,11 +558,15 @@ int main(int argc, char *argv[])
 				// - Fixes intro "select" error
 				feVM.clear_commands();
 
-				if ( first_intro && mode == FeSettings::LaunchLastGame )
+				if ( initial_load && mode == FeSettings::LaunchLastGame )
 				{
-					// Only LaunchLastGame on first run, not after manually triggered intro
-					has_layout = feSettings.select_last_launch();
-					if ( has_layout ) feVM.load_layout( true );
+					// Only LaunchLastGame on initial_load, not after manually triggered intro
+					has_layout = feSettings.select_last_launch( initial_load );
+					if ( has_layout )
+					{
+						feVM.load_layout( initial_load );
+						initial_load = false;
+					}
 					launch_game = true;
 				}
 
@@ -577,7 +580,8 @@ int main(int argc, char *argv[])
 				if ( !has_layout )
 				{
 					feSettings.set_display( feSettings.get_selected_display_index() );
-					feVM.load_layout( true );
+					feVM.load_layout( initial_load );
+					initial_load = false;
 				}
 
 				if ( c == FeInputMap::LAST_COMMAND ) continue;
@@ -624,7 +628,7 @@ int main(int argc, char *argv[])
 								display_index = last_display_index;
 								last_display_index = -1;
 								feSettings.set_display( display_index );
-								feVM.load_layout( true );
+								feVM.load_layout();
 								redraw=true;
 								break;
 							}
@@ -817,7 +821,8 @@ int main(int argc, char *argv[])
 							}
 
 							feSettings.set_display( display_index );
-							feVM.load_layout( true );
+							feVM.load_layout( initial_load );
+							initial_load = false;
 							redraw=true;
 							break;
 						}


### PR DESCRIPTION
- `StartLayout` `FromTo.Frontend` only sent to first encountered `load_layout`
- For `Startup Mode: Show Displays Menu` the Custom menu layout will receive `FromTo.Frontend`
- Fixed `Startup Mode: Launch Last Game` when `Group Clones` set