### PR TITLE
Update Combo-Key Controls

### DIFF
--- a/src/fe_input.hpp
+++ b/src/fe_input.hpp
@@ -202,10 +202,10 @@ public:
 	//
 	bool get_current_state( FeInputMap::Command c, int joy_thresh ) const;
 
-	// call this after all the mappings have been loaded (with either process_setting calls or
-	// set_mapping()
-	//
+	// call this after all the mappings have been loaded (with either process_setting calls or set_mapping()
 	void initialize_mappings();
+	// clear m_tracked_keys (call when focus is lost to prevent holding expired keys)
+	void clear_tracked_keys();
 
 	// fix mappings when joystick connected/disconnected
 	void on_joystick_connect();
@@ -234,7 +234,7 @@ public:
 
 private:
 
-	Command get_command_from_tracked_keys( const int joy_thresh ) const;
+	Command get_command_from_tracked_keys() const;
 
 	// TO allow for key combos, we maintain an initial map of all single input events, mapping
 	// them to all of the entries in m_inputs that contain the same single input

--- a/src/fe_present.cpp
+++ b/src/fe_present.cpp
@@ -1406,6 +1406,7 @@ void FePresent::post_run()
 	on_transition( FromGame, FromToNoValue );
 #endif
 
+	m_feSettings->reset_input();
 	reset_screen_saver();
 	update_to( ToNewList, false );
 }

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -917,6 +917,11 @@ void FeSettings::load_state()
 	}
 }
 
+void FeSettings::reset_input()
+{
+	m_inputmap.clear_tracked_keys();
+}
+
 FeInputMap::Command FeSettings::map_input( const std::optional<sf::Event> &e )
 {
 	if ( e.has_value() )

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -326,6 +326,7 @@ public:
 	void save_state();
 
 	FeInputMap::Command map_input( const std::optional<sf::Event> &e );
+	void reset_input();
 
 	void get_input_config_metrics( sf::IntRect &mousecap_rect, int &joy_thresh );
 	FeInputMap::Command input_conflict_check( const FeInputMapEntry &e );


### PR DESCRIPTION
- Combo controls must now hold all required keys to trigger
- Sequential key presses will no longer trigger a combo control
- Triggered controls no longer clear held keys, allowing a common key to be held while triggering other combos (ie: shifted keyset)

### Test
- To reproduce issue in prior builds see: https://github.com/oomek/attractplus/issues/161
- To test new behavior use: https://github.com/oomek/attractplus/actions/runs/16106834233
- Configure > Controls
  - Previous Letter > LShift + Up
  - Next Letter > LShift + Down
- `Previous Letter` will activate ONLY when `LShift` and `Up` are BOTH pressed together.
- Continue holding `LShift` from the last command, then press `Down` to trigger `Next Letter`