### PR TITLE
Improve Filter Performance

### DIFF
--- a/src/fe_info.hpp
+++ b/src/fe_info.hpp
@@ -214,6 +214,7 @@ private:
 	std::string m_filter_what;
 	SQRex *m_rex;
 	bool m_is_exception;
+	bool m_use_rex;
 };
 
 //


### PR DESCRIPTION
- Avoid performing regex for filters where possible

```
BEFORE
 - Loaded romlist 'Mame' in 338 ms (39825 entries from romlist, 9013 kept, updated romlist cache, updated globalfilter cache)
 - Loaded filters in 64 ms (6 filters, 0 from cache, 54078 comparisons)
 - Loaded romlist 'Mame' in 361 ms (39825 entries from romlist, 9013 kept, updated romlist cache, updated globalfilter cache)
 - Loaded filters in 64 ms (6 filters, 0 from cache, 54078 comparisons)
 - Loaded romlist 'Mame' in 364 ms (39825 entries from romlist, 9013 kept, updated romlist cache, updated globalfilter cache)
 - Loaded filters in 76 ms (6 filters, 0 from cache, 54078 comparisons)

AFTER
 - Loaded romlist 'Mame' in 262 ms (39825 entries from romlist, 9013 kept, updated romlist cache, updated globalfilter cache)
 - Loaded filters in 64 ms (6 filters, 0 from cache, 54078 comparisons)
 - Loaded romlist 'Mame' in 256 ms (39825 entries from romlist, 9013 kept, updated romlist cache, updated globalfilter cache)
 - Loaded filters in 60 ms (6 filters, 0 from cache, 54078 comparisons)
 - Loaded romlist 'Mame' in 252 ms (39825 entries from romlist, 9013 kept, updated romlist cache, updated globalfilter cache)
 - Loaded filters in 59 ms (6 filters, 0 from cache, 54078 comparisons)
```