### PR TITLE
Replace sf::Clock with stable timer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@
 
 #FE_DEBUG=1
 #VERBOSE=1
-#WINDOWS_XP=1
 
 override FE_VERSION := v3.1.2
 
@@ -311,11 +310,7 @@ endif
 ifeq ($(FE_WINDOWS_COMPILE),1)
  _DEP += attractplus.rc
  _OBJ += attractplus.res
- ifeq ($(WINDOWS_XP),1)
-  FE_FLAGS += -DWINDOWS_XP
- else
-  LIBS += -ldwmapi
- endif
+ LIBS += -ldwmapi
  ifeq ($(WINDOWS_CONSOLE),1)
   CFLAGS += -mconsole
   FE_FLAGS += -DWINDOWS_CONSOLE

--- a/src/fe_audio_fx.cpp
+++ b/src/fe_audio_fx.cpp
@@ -620,13 +620,12 @@ void FeAudioVisualiser::update_fall() const
 {
 	sf::Time current_time = m_system_clock.getElapsedTime();
 
-	float delta_time = ( current_time - m_last_frame_time ).asSeconds();
-	m_last_frame_time = current_time;
-
-	float refresh_rate = 60.0f;
 	FePresent *fep = FePresent::script_get_fep();
 	if ( fep )
-		refresh_rate = static_cast<float>( fep->get_refresh_rate() );
+		current_time = fep->get_layout_time();
+
+	float delta_time = ( current_time - m_last_frame_time ).asSeconds();
+	m_last_frame_time = current_time;
 
 	float vu_fall_amount = VU_FALL_SPEED * delta_time;
 	float fft_fall_amount = FFT_FALL_SPEED * delta_time;

--- a/src/fe_music.hpp
+++ b/src/fe_music.hpp
@@ -38,7 +38,6 @@ private:
 	std::string m_file_name;
 	bool m_play_state;
 	float m_volume;
-	sf::Clock m_system_clock;
 
 	FeAudioEffectsManager m_audio_effects;
 

--- a/src/fe_present.cpp
+++ b/src/fe_present.cpp
@@ -1774,7 +1774,7 @@ const sf::Vector2i FePresent::get_screen_size()
 		return m_mon[0].size;
 }
 
-FeStableTimer::FeStableTimer()
+FeStableClock::FeStableClock()
 	: m_time( sf::Time::Zero ),
 	m_refresh_rate( 60 )
 {
@@ -1782,18 +1782,18 @@ FeStableTimer::FeStableTimer()
 	m_real_timer.reset();
 }
 
-void FeStableTimer::start()
+void FeStableClock::start()
 {
 	m_real_timer.start();
 }
 
-void FeStableTimer::reset()
+void FeStableClock::reset()
 {
 	m_real_timer.reset();
 	m_time = sf::Time::Zero;
 }
 
-void FeStableTimer::tick()
+void FeStableClock::tick()
 {
 	sf::Time real_elapsed = m_real_timer.getElapsedTime();
 	sf::Time stable_increment = sf::microseconds( 1000000 / m_refresh_rate );
@@ -1811,12 +1811,12 @@ void FeStableTimer::tick()
 		m_real_timer.start();
 }
 
-sf::Time FeStableTimer::getElapsedTime()
+sf::Time FeStableClock::getElapsedTime()
 {
 	return m_time;
 }
 
-void FeStableTimer::set_refresh_rate( int rate )
+void FeStableClock::set_refresh_rate( int rate )
 {
 	m_refresh_rate = rate;
 }

--- a/src/fe_present.cpp
+++ b/src/fe_present.cpp
@@ -1680,6 +1680,11 @@ int FePresent::get_layout_ms()
 	return m_layoutTimer.getElapsedTime().asMilliseconds();
 }
 
+sf::Time FePresent::get_layout_time()
+{
+	return m_layoutTimer.getElapsedTime();
+}
+
 int FePresent::get_refresh_rate()
 {
 	return m_refresh_rate;

--- a/src/fe_present.hpp
+++ b/src/fe_present.hpp
@@ -107,6 +107,21 @@ public:
 	int num;
 };
 
+class FeStableTimer
+{
+public:
+	FeStableTimer();
+	void start();
+	void reset();
+	void tick();
+	sf::Time getElapsedTime();
+	void set_refresh_rate( int rate );
+
+private:
+	sf::Clock m_real_timer;
+	sf::Time m_time;
+	int m_refresh_rate;
+};
 
 class FePresent
 	: public sf::Drawable
@@ -130,7 +145,7 @@ protected:
 	std::string m_layoutFontName;
 	sf::Image *m_logo_image;
 
-	sf::Clock m_layoutTimer;
+	FeStableTimer m_layoutTimer;
 	sf::Time m_lastInput;
 
 	FeSettings::RotationState m_baseRotation;

--- a/src/fe_present.hpp
+++ b/src/fe_present.hpp
@@ -277,6 +277,7 @@ public:
 	bool get_video_toggle() { return m_playMovies; };
 
 	int get_layout_ms();
+	sf::Time get_layout_time();
 	int get_refresh_rate();
 	bool get_mouse_pointer();
 	void set_mouse_pointer( bool );

--- a/src/fe_present.hpp
+++ b/src/fe_present.hpp
@@ -107,10 +107,10 @@ public:
 	int num;
 };
 
-class FeStableTimer
+class FeStableClock
 {
 public:
-	FeStableTimer();
+	FeStableClock();
 	void start();
 	void reset();
 	void tick();
@@ -145,7 +145,7 @@ protected:
 	std::string m_layoutFontName;
 	sf::Image *m_logo_image;
 
-	FeStableTimer m_layoutTimer;
+	FeStableClock m_layoutTimer;
 	sf::Time m_lastInput;
 
 	FeSettings::RotationState m_baseRotation;

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1362,6 +1362,8 @@ bool FeVM::on_tick()
 			++itr;
 	}
 
+	m_layoutTimer.tick();
+
 	return m_redraw_triggered;
 }
 

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1375,7 +1375,7 @@ void FeVM::on_transition(
 
 	FeDebug() << "[Transition] type=" << transitionTypeStrings[t] << ", var=" << var << std::endl;
 
-	sf::Clock clk;
+	FeStableClock clk;
 	int ttime = 0;
 
 	std::vector<FeCallback *> worklist( m_trans.size() );
@@ -1429,6 +1429,7 @@ void FeVM::on_transition(
 		if (( !worklist.empty() ) && ( m_window.isOpen() ))
 		{
 			video_tick();
+			clk.tick();
 
 			redraw_surfaces();
 			m_window.clear();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1151,10 +1151,7 @@ int main(int argc, char *argv[])
 		else
 			has_focus = window.hasFocus();
 
-		if ( feVM.on_tick() )
-			redraw=true;
-
-		if ( feVM.video_tick() )
+		if ( feVM.tick() )
 			redraw=true;
 
 		if ( feVM.saver_activation_check() )

--- a/src/media.hpp
+++ b/src/media.hpp
@@ -131,8 +131,6 @@ private:
 	FeAudioEffectsManager m_audio_effects;
 	void setup_effect_processor();
 
-	sf::Clock m_system_clock;
-
 	FeMedia( const FeMedia & );
 	FeMedia &operator=( const FeMedia & );
 	float m_aspect_ratio;


### PR DESCRIPTION
In triple buffering with heavy load frame times may vary significantly even if the frame rate is stable. Stable timer prevents stuttering of animations that rely on ttime and fe.layout.time