### PR TITLE
Improve FFT array get operations speed by x10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ _DEP =\
 	path_cache.hpp \
 	image_loader.hpp \
 	base64.hpp \
+	sqrat_array_wrapper.hpp \
 	zip.hpp
 
 _OBJ =\
@@ -210,6 +211,7 @@ _OBJ =\
 	path_cache.o \
 	image_loader.o \
 	base64.o \
+	sqrat_array_wrapper.o \
 	main.o
 
 _RES =\

--- a/src/fe_audio_fx.cpp
+++ b/src/fe_audio_fx.cpp
@@ -402,67 +402,34 @@ float FeAudioVisualiser::get_vu_right() const
 	return m_vu_right_out;
 }
 
-Sqrat::Array FeAudioVisualiser::get_fft_array_mono() const
+const std::vector<float> *FeAudioVisualiser::get_fft_mono_ptr() const
 {
 	m_fft_requested = true;
 	FePresent *fep = FePresent::script_get_fep();
 	if ( fep )
 		m_fft_request_time = fep->get_layout_time();
 
-	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
-
-	Sqrat::Table fft_table( vm );
-	for ( int i = 0; i < FFT_BANDS_MAX; ++i )
-	{
-		if ( i < m_fft_bands )
-			fft_table.SetValue( i, m_fft_mono_out[i] );
-		else
-			fft_table.SetValue( i, 0.0f );
-	}
-
-	return Sqrat::Array( fft_table.GetObject(), vm );
+	return &m_fft_mono_out;
 }
 
-Sqrat::Array FeAudioVisualiser::get_fft_array_left() const
+const std::vector<float> *FeAudioVisualiser::get_fft_left_ptr() const
 {
 	m_fft_requested = true;
 	FePresent *fep = FePresent::script_get_fep();
 	if ( fep )
 		m_fft_request_time = fep->get_layout_time();
 
-	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
-
-	Sqrat::Table fft_table( vm );
-	for ( int i = 0; i < FFT_BANDS_MAX; ++i )
-	{
-		if ( i < m_fft_bands )
-			fft_table.SetValue( i, m_fft_left_out[i] );
-		else
-			fft_table.SetValue( i, 0.0f );
-	}
-
-	return Sqrat::Array( fft_table.GetObject(), vm );
+	return &m_fft_left_out;
 }
 
-Sqrat::Array FeAudioVisualiser::get_fft_array_right() const
+const std::vector<float> *FeAudioVisualiser::get_fft_right_ptr() const
 {
 	m_fft_requested = true;
 	FePresent *fep = FePresent::script_get_fep();
 	if ( fep )
 		m_fft_request_time = fep->get_layout_time();
 
-	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
-
-	Sqrat::Table fft_table( vm );
-	for ( int i = 0; i < FFT_BANDS_MAX; ++i )
-	{
-		if ( i < m_fft_bands )
-			fft_table.SetValue( i, m_fft_right_out[i] );
-		else
-			fft_table.SetValue( i, 0.0f );
-	}
-
-	return Sqrat::Array( fft_table.GetObject(), vm );
+	return &m_fft_right_out;
 }
 
 void FeAudioVisualiser::calculate_fft_channel( const float* samples, unsigned int sample_count,

--- a/src/fe_audio_fx.hpp
+++ b/src/fe_audio_fx.hpp
@@ -117,10 +117,9 @@ public:
 	float get_vu_left() const;
 	float get_vu_right() const;
 
-	// Sqrat bindings for FFT arrays
-	Sqrat::Array get_fft_array_mono() const;
-	Sqrat::Array get_fft_array_left() const;
-	Sqrat::Array get_fft_array_right() const;
+	const std::vector<float> *get_fft_mono_ptr() const;
+	const std::vector<float> *get_fft_left_ptr() const;
+	const std::vector<float> *get_fft_right_ptr() const;
 
 	static constexpr int FFT_BANDS_MAX = 128;
 

--- a/src/fe_image.cpp
+++ b/src/fe_image.cpp
@@ -1060,6 +1060,9 @@ FePresentableParent *FeSurfaceTextureContainer::get_presentable_parent()
 FeImage::FeImage( FePresentableParent &p,
 	FeBaseTextureContainer *tc, float x, float y, float w, float h )
 	: FeBasePresentable( p ),
+	m_fft_data_zero( FeAudioVisualiser::FFT_BANDS_MAX, 0.0f ),
+	m_fft_zero_wrapper( &m_fft_data_zero ),
+	m_fft_array_wrapper( &m_fft_data_zero ),
 	m_tex( tc ),
 	m_pos( x, y ),
 	m_size( w, h ),
@@ -1080,6 +1083,9 @@ FeImage::FeImage( FePresentableParent &p,
 
 FeImage::FeImage( FeImage *o )
 	: FeBasePresentable( *o ),
+	m_fft_data_zero( 128, 0.0f ),
+	m_fft_zero_wrapper( &m_fft_data_zero ),
+	m_fft_array_wrapper( &m_fft_data_zero ),
 	m_tex( o->m_tex ),
 	m_sprite( o->m_sprite ),
 	m_pos( o->m_pos ),
@@ -1885,55 +1891,61 @@ float FeImage::get_vu_right() const
 	return 0.0f;
 }
 
-Sqrat::Array FeImage::get_fft_array_mono()
+const SqratArrayWrapper& FeImage::get_fft_array_mono() const
 {
 	FeTextureContainer *tc = dynamic_cast<FeTextureContainer*>( m_tex );
 	if ( tc )
 	{
 		FeMedia *media = tc->get_media();
 		if ( media )
-			return media->get_fft_array_mono();
+		{
+			if ( media->get_fft_mono_ptr() )
+			{
+				m_fft_array_wrapper.set_data( media->get_fft_mono_ptr() );
+				return m_fft_array_wrapper;
+			}
+		}
 	}
 
-	Sqrat::Array arr( Sqrat::DefaultVM::Get(), FeAudioVisualiser::FFT_BANDS_MAX );
-	for ( int i = 0; i < FeAudioVisualiser::FFT_BANDS_MAX; ++i )
-		arr.SetValue( i, 0.0f );
-
-	return arr;
+	return m_fft_zero_wrapper;
 }
 
-Sqrat::Array FeImage::get_fft_array_left()
+const SqratArrayWrapper& FeImage::get_fft_array_left() const
 {
 	FeTextureContainer *tc = dynamic_cast<FeTextureContainer*>( m_tex );
 	if ( tc )
 	{
 		FeMedia *media = tc->get_media();
 		if ( media )
-			return media->get_fft_array_left();
+		{
+			if ( media->get_fft_left_ptr() )
+			{
+				m_fft_array_wrapper.set_data( media->get_fft_left_ptr() );
+				return m_fft_array_wrapper;
+			}
+		}
 	}
 
-	Sqrat::Array arr( Sqrat::DefaultVM::Get(), FeAudioVisualiser::FFT_BANDS_MAX );
-	for ( int i = 0; i < FeAudioVisualiser::FFT_BANDS_MAX; ++i )
-		arr.SetValue( i, 0.0f );
-
-	return arr;
+	return m_fft_zero_wrapper;
 }
 
-Sqrat::Array FeImage::get_fft_array_right()
+const SqratArrayWrapper& FeImage::get_fft_array_right() const
 {
 	FeTextureContainer *tc = dynamic_cast<FeTextureContainer*>( m_tex );
 	if ( tc )
 	{
 		FeMedia *media = tc->get_media();
 		if ( media )
-			return media->get_fft_array_right();
+		{
+			if ( media->get_fft_right_ptr() )
+			{
+				m_fft_array_wrapper.set_data( media->get_fft_right_ptr() );
+				return m_fft_array_wrapper;
+			}
+		}
 	}
 
-	Sqrat::Array arr( Sqrat::DefaultVM::Get(), FeAudioVisualiser::FFT_BANDS_MAX );
-	for ( int i = 0; i < FeAudioVisualiser::FFT_BANDS_MAX; ++i )
-		arr.SetValue( i, 0.0f );
-
-	return arr;
+	return m_fft_zero_wrapper;
 }
 
 void FeImage::transition_swap( FeImage *o )

--- a/src/fe_image.hpp
+++ b/src/fe_image.hpp
@@ -28,6 +28,7 @@
 #include "sprite.hpp"
 #include "fe_presentable.hpp"
 #include "fe_blend.hpp"
+#include "sqrat_array_wrapper.hpp"
 
 class FeSettings;
 class FeMedia;
@@ -368,9 +369,9 @@ public:
 	float get_vu_mono() const;
 	float get_vu_left() const;
 	float get_vu_right() const;
-	Sqrat::Array get_fft_array_mono();
-	Sqrat::Array get_fft_array_left();
-	Sqrat::Array get_fft_array_right();
+	const SqratArrayWrapper& get_fft_array_mono() const;
+	const SqratArrayWrapper& get_fft_array_left() const;
+	const SqratArrayWrapper& get_fft_array_right() const;
 	void set_fft_bands( int count );
 	int get_fft_bands() const;
 
@@ -457,6 +458,12 @@ protected:
 
 	// Override from base class:
 	void draw(sf::RenderTarget& target, sf::RenderStates states) const;
+
+private:
+	std::vector<float> m_fft_data_zero;
+	mutable SqratArrayWrapper m_fft_zero_wrapper;
+	mutable SqratArrayWrapper m_fft_array_wrapper;
+
 };
 
 #endif

--- a/src/fe_music.cpp
+++ b/src/fe_music.cpp
@@ -41,7 +41,10 @@
 
 FeMusic::FeMusic( bool loop )
 	: m_file_name( "" ),
-	m_volume( 100.0 )
+	m_volume( 100.0 ),
+	m_fft_data_zero( FeAudioVisualiser::FFT_BANDS_MAX, 0.0f ),
+	m_fft_zero_wrapper( &m_fft_data_zero ),
+	m_fft_array_wrapper( &m_fft_data_zero )
 {
 	m_music.setLooping( loop );
 	m_audio_effects.add_effect( std::make_unique<FeAudioDCFilter>() );
@@ -292,19 +295,46 @@ float FeMusic::get_vu_right()
 	return get_audio_visualiser()->get_vu_right();
 }
 
-Sqrat::Array FeMusic::get_fft_array_mono()
+const SqratArrayWrapper& FeMusic::get_fft_array_mono() const
 {
-	return get_audio_visualiser()->get_fft_array_mono();
+	if ( get_audio_visualiser() )
+	{
+		if ( get_audio_visualiser()->get_fft_mono_ptr() )
+			{
+				m_fft_array_wrapper.set_data( get_audio_visualiser()->get_fft_mono_ptr() );
+				return m_fft_array_wrapper;
+			}
+	}
+
+	return m_fft_zero_wrapper;
 }
 
-Sqrat::Array FeMusic::get_fft_array_left()
+const SqratArrayWrapper& FeMusic::get_fft_array_left() const
 {
-	return get_audio_visualiser()->get_fft_array_left();
+	if ( get_audio_visualiser() )
+	{
+		if ( get_audio_visualiser()->get_fft_left_ptr() )
+			{
+				m_fft_array_wrapper.set_data( get_audio_visualiser()->get_fft_left_ptr() );
+				return m_fft_array_wrapper;
+			}
+	}
+
+	return m_fft_zero_wrapper;
 }
 
-Sqrat::Array FeMusic::get_fft_array_right()
+const SqratArrayWrapper& FeMusic::get_fft_array_right() const
 {
-	return get_audio_visualiser()->get_fft_array_right();
+	if ( get_audio_visualiser() )
+	{
+		if ( get_audio_visualiser()->get_fft_right_ptr() )
+			{
+				m_fft_array_wrapper.set_data( get_audio_visualiser()->get_fft_right_ptr() );
+				return m_fft_array_wrapper;
+			}
+	}
+
+	return m_fft_zero_wrapper;
 }
 
 void FeMusic::set_fft_bands( int count )

--- a/src/fe_music.hpp
+++ b/src/fe_music.hpp
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <sqrat.h>
 #include "fe_audio_fx.hpp"
+#include "sqrat_array_wrapper.hpp"
 
 class FeMusic
 {
@@ -80,11 +81,17 @@ public:
 	float get_vu_mono();
 	float get_vu_left();
 	float get_vu_right();
-	Sqrat::Array get_fft_array_mono();
-	Sqrat::Array get_fft_array_left();
-	Sqrat::Array get_fft_array_right();
+	const SqratArrayWrapper& get_fft_array_mono() const;
+	const SqratArrayWrapper& get_fft_array_left() const;
+	const SqratArrayWrapper& get_fft_array_right() const;
 	void set_fft_bands( int count );
 	int get_fft_bands() const;
+
+private:
+	std::vector<float> m_fft_data_zero;
+	mutable SqratArrayWrapper m_fft_zero_wrapper;
+	mutable SqratArrayWrapper m_fft_array_wrapper;
+
 };
 
 #endif // FE_MUSIC_HPP

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1059,6 +1059,12 @@ bool FeVM::on_new_layout()
 		.Prop( _SC("bg_load"), &FeImageLoader::get_background_loading, &FeImageLoader::set_background_loading )
 	);
 
+	Sqrat::Class<SqratArrayWrapper> SqratWrapperClass( fe.GetVM(), _SC("SqratWrapperClass") );
+	SqratWrapperClass.Func( _SC("_get"), &SqratArrayWrapper::_get );
+	SqratWrapperClass.Func( _SC("_nexti"), &SqratArrayWrapper::_nexti );
+	SqratWrapperClass.Func( _SC("len"), &SqratArrayWrapper::len );
+	fe.Bind( _SC("SqratArrayWrapper"), SqratWrapperClass );
+
 	//
 	// Define functions that get exposed to Squirrel
 	//

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -1759,37 +1759,28 @@ float FeMedia::get_vu_mono()
 	return visualiser ? visualiser->get_vu_mono() : 0.0f;
 }
 
-Sqrat::Array FeMedia::get_fft_array_mono()
+const std::vector<float> *FeMedia::get_fft_mono_ptr()
 {
 	auto* visualiser = get_audio_visualiser();
 	if ( visualiser )
-		return visualiser->get_fft_array_mono();
-
-	// Return empty array if no visualiser
-	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
-	return Sqrat::Array( vm );
+		return visualiser->get_fft_mono_ptr();
+	return nullptr;
 }
 
-Sqrat::Array FeMedia::get_fft_array_left()
+const std::vector<float> *FeMedia::get_fft_left_ptr()
 {
 	auto* visualiser = get_audio_visualiser();
 	if ( visualiser )
-		return visualiser->get_fft_array_left();
-
-	// Return empty array if no visualiser
-	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
-	return Sqrat::Array( vm );
+		return visualiser->get_fft_left_ptr();
+	return nullptr;
 }
 
-Sqrat::Array FeMedia::get_fft_array_right()
+const std::vector<float> *FeMedia::get_fft_right_ptr()
 {
 	auto* visualiser = get_audio_visualiser();
 	if ( visualiser )
-		return visualiser->get_fft_array_right();
-
-	// Return empty array if no visualiser
-	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
-	return Sqrat::Array( vm );
+		return visualiser->get_fft_right_ptr();
+	return nullptr;
 }
 
 void FeMedia::set_fft_bands( int count )

--- a/src/media.hpp
+++ b/src/media.hpp
@@ -102,9 +102,10 @@ public:
 	float get_vu_mono();
 	float get_vu_left();
 	float get_vu_right();
-	Sqrat::Array get_fft_array_mono();
-	Sqrat::Array get_fft_array_left();
-	Sqrat::Array get_fft_array_right();
+
+	const std::vector<float> *get_fft_mono_ptr();
+	const std::vector<float> *get_fft_left_ptr();
+	const std::vector<float> *get_fft_right_ptr();
 
 	void set_fft_bands( int count );
 	int get_fft_bands() const;

--- a/src/sqrat_array_wrapper.cpp
+++ b/src/sqrat_array_wrapper.cpp
@@ -1,0 +1,59 @@
+/*
+ *
+ *  Attract-Mode Plus frontend
+ *  Copyright (C) 2025 Andrew Mickelson & Radek Dutkiewicz
+ *
+ *  This file is part of Attract-Mode Plus
+ *
+ *  Attract-Mode Plus is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Attract-Mode Plus is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Attract-Mode Plus.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "sqrat_array_wrapper.hpp"
+
+SqratArrayWrapper::SqratArrayWrapper( const std::vector<float> *data )
+	: m_data( data )
+{
+}
+
+void SqratArrayWrapper::set_data( const std::vector<float> *data )
+{
+	m_data = data;
+}
+
+float SqratArrayWrapper::_get( int index )
+{
+	if ( m_data && index >= 0 && index < static_cast<int>( m_data->size() ))
+		return ( *m_data )[index];
+
+	return 0.0f;
+}
+
+int SqratArrayWrapper::len() const
+{
+	return m_data ? static_cast<int>( m_data->size() ) : 0;
+}
+
+int SqratArrayWrapper::_nexti( int prev_index )
+{
+	if ( !m_data ) return -1;
+
+	if ( prev_index < 0 ) // First call
+	{
+		return m_data->empty() ? -1 : 0;
+	}
+
+	int next_index = prev_index + 1;
+	return ( next_index < static_cast<int>( m_data->size() )) ? next_index : -1;
+}

--- a/src/sqrat_array_wrapper.hpp
+++ b/src/sqrat_array_wrapper.hpp
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Attract-Mode Plus frontend
+ *  Copyright (C) 2025 Andrew Mickelson & Radek Dutkiewicz
+ *
+ *  This file is part of Attract-Mode Plus
+ *
+ *  Attract-Mode Plus is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Attract-Mode Plus is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Attract-Mode Plus.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef FE_SQRAT_ARRAY_WRAPPER_HPP
+#define FE_SQRAT_ARRAY_WRAPPER_HPP
+
+#include <vector>
+
+class SqratArrayWrapper
+{
+private:
+	const std::vector<float>* m_data;
+
+public:
+	SqratArrayWrapper( const std::vector<float> *data );
+
+	void set_data( const std::vector<float> *data );
+	float _get( int index );
+	int len() const;
+	int _nexti( int prev_index );
+};
+
+#endif


### PR DESCRIPTION
Test layout:
```cpp
local flw = fe.layout.width
local flh = fe.layout.height


// test music
// local vid = fe.add_music("mp3/DC02-03.MP3")
// vid.playing = true


// test video
local vid = fe.add_artwork("snap", 0, 0, flw, flh)


vid.fft_bands = 128

local n = vid.fft_bands
local w = flw.tofloat() / n

local bars_m = []
local bars_l = []
local bars_r = []

for (local i = 0; i < n; i++)
{
    local r = fe.add_rectangle(i * w, 0, w, 0)
    r.set_rgb(255, 100, 100)
    r.anchor = Anchor.TopLeft
    bars_l.push(r)
}

for (local i = 0; i < n; i++)
{
    local r = fe.add_rectangle(i * w, flh/2, w, 0)
    r.set_rgb(100, 255, 100)
    r.anchor = Anchor.Left
    bars_m.push(r)
}

for (local i = 0; i < n; i++)
{
    local r = fe.add_rectangle(i * w, flh, w, 0)
    r.set_rgb(100, 100, 255)
    r.anchor = Anchor.BottomLeft
    bars_r.push(r)
}

fe.add_ticks_callback("on_tick")
function on_tick(ttime)
{
    for (local i = 0; i < n; i++) bars_m[i].height = vid.fft[i] * flh/2
    for (local i = 0; i < n; i++) bars_l[i].height = vid.fft_left[i] * flh/2
    for (local i = 0; i < n; i++) bars_r[i].height = vid.fft_right[i] * flh/2
}
```