### PR TITLE
Update default config values

### DIFF
--- a/src/fe_present.cpp
+++ b/src/fe_present.cpp
@@ -293,7 +293,7 @@ void FePresent::init_monitors()
 		// On Windows 'Fill screen' mode our window is offscreen 1 pixel in each direction, so correct
 		// for that here to align draw area with screen
 		//
-		if ( m_feSettings->get_window_mode() == FeSettings::Default )
+		if ( m_feSettings->get_window_mode() == FeSettings::Fillscreen )
 		{
 			translate_x += 1;
 			translate_y += 1;
@@ -397,7 +397,7 @@ void FePresent::init_monitors()
 		// On Windows 'Fill screen' mode our window is offscreen 1 pixel in each direction, so correct
 		// for that here to align draw area with screen.
 		//
-		if ( m_feSettings->get_window_mode() == FeSettings::Default )
+		if ( m_feSettings->get_window_mode() == FeSettings::Fillscreen )
 		{
 			mc.size.x -= 2;
 			mc.size.y -= 2;

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -167,7 +167,7 @@ FeLanguage::FeLanguage(
 
 const char *FeSettings::windowModeTokens[] =
 {
-	"default",
+	"fillscreen",
 	"fullscreen",
 	"window",
 	"window_no_border",
@@ -241,7 +241,7 @@ const char *FeSettings::anisotropicDispTokens[] =
 
 const char *FeSettings::filterWrapTokens[] =
 {
-	"default",
+	"wrap_within_display",
 	"jump_to_next_display",
 	"no_wrap",
 	NULL
@@ -257,7 +257,7 @@ const char *FeSettings::filterWrapDispTokens[] =
 
 const char *FeSettings::startupTokens[] =
 {
-	"default",
+	"show_last_selection",
 	"launch_last_game",
 	"displays_menu",
 	NULL
@@ -349,7 +349,7 @@ FeSettings::FeSettings( const std::string &config_path )
 #if defined(SFML_SYSTEM_LINUX) || defined(FORCE_FULLSCREEN)
 	m_window_mode( Fullscreen ),
 #else
-	m_window_mode( Default ),
+	m_window_mode( Fillscreen ),
 #endif
 	m_smooth_images( true ),
 	m_filter_wrap_mode( WrapWithinDisplay ),

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -105,7 +105,7 @@ public:
 		ScreenSaver_Showing
 	};
 
-	enum WindowType { Default=0, Fullscreen, Window, WindowNoBorder };
+	enum WindowType { Fillscreen=0, Fullscreen, Window, WindowNoBorder };
 	static const char *windowModeTokens[];
 	static const char *windowModeDispTokens[];
 

--- a/src/fe_window.cpp
+++ b/src/fe_window.cpp
@@ -207,7 +207,7 @@ void FeWindow::initial_create()
 
 	int style_map[4] =
 	{
-		sf::Style::None,       // FeSettings::Default
+		sf::Style::None,       // FeSettings::Fillscreen
 		sf::Style::None,       // FeSettings::Fullscreen
 		sf::Style::Default,    // FeSettings::Window
 		sf::Style::None        // FeSettings::WindowNoBorder
@@ -215,7 +215,7 @@ void FeWindow::initial_create()
 
 	sf::State state_map[4] =
 	{
-		sf::State::Windowed,   // FeSettings::Default
+		sf::State::Windowed,   // FeSettings::Fillscreen
 		sf::State::Fullscreen, // FeSettings::Fullscreen
 		sf::State::Windowed,   // FeSettings::Window
 		sf::State::Windowed    // FeSettings::WindowNoBorder
@@ -292,7 +292,7 @@ void FeWindow::initial_create()
 		// have detected that multiple monitors are available
 		//
 		FeLog() << " ! NOTE: Switching to 'Fill Screen' window mode (required for multiple monitor support)." << std::endl;
-		m_win_mode = FeSettings::Default;
+		m_win_mode = FeSettings::Fillscreen;
 	}
 
 	// Cover all available monitors with our window in multimonitor config
@@ -319,7 +319,7 @@ void FeWindow::initial_create()
 	// which seems to be the cause of this issue.  This is actually the same behaviour that earlier
 	// versions of Attract-Mode had (first by design, then by accident).
 	//
-	if ( m_win_mode == FeSettings::Default )
+	if ( m_win_mode == FeSettings::Fillscreen )
 	{
 		wpos.x -= 1;
 		wpos.y -= 1;
@@ -436,7 +436,7 @@ void FeWindow::initial_create()
 	display();
 
 #ifdef SFML_SYSTEM_MACOS
-	if ( m_win_mode == FeSettings::Default )
+	if ( m_win_mode == FeSettings::Fillscreen )
 	{
 		// note ordering req: pretty sure this needs to be before the setPosition() call below
 		osx_hide_menu_bar();
@@ -444,7 +444,7 @@ void FeWindow::initial_create()
 #endif
 
 #if defined(USE_XLIB)
-	if ( m_win_mode == FeSettings::Default )
+	if ( m_win_mode == FeSettings::Fillscreen )
 		set_x11_fullscreen_state( m_window->getNativeHandle() );
 #endif
 


### PR DESCRIPTION
Update default tokens to meaningful values, for example: `"default"` -> `"fillscreen"`
AM will complain about *Unrecognized values*, but since the default options are listed first they get selected anyway.
Obsolete tokens get updated when the config is next saved.