### PR TITLE
Update config colour format

### DIFF
--- a/src/fe_config.cpp
+++ b/src/fe_config.cpp
@@ -1680,17 +1680,17 @@ void FeMiscMenu::get_options( FeConfigContext &ctx )
 
 	// ---------------------------------------------------------------------------------
 
-	std::string uicol_hex = ctx.fe_settings.get_ui_color();
+	std::string uicol_token = ctx.fe_settings.get_ui_color();
 	std::vector<std::string>::iterator uicol_item = FeSettings::uiColorTokens.begin();
-	if ( !uicol_hex.empty() )
+	if ( !uicol_token.empty() )
 	{
 		// Find the selected ui colour
-		uicol_item = std::find( FeSettings::uiColorTokens.begin(), FeSettings::uiColorTokens.end(), uicol_hex );
+		uicol_item = std::find( FeSettings::uiColorTokens.begin(), FeSettings::uiColorTokens.end(), uicol_token );
 
 		// If not found add a custom colour option to the lists
 		if ( uicol_item == FeSettings::uiColorTokens.end() )
 		{
-			FeSettings::uiColorTokens.push_back( uicol_hex );
+			FeSettings::uiColorTokens.push_back( uicol_token );
 			FeSettings::uiColorDispTokens.push_back( _( "Custom" ) );
 			uicol_item = --FeSettings::uiColorTokens.end();
 		}

--- a/src/fe_overlay.cpp
+++ b/src/fe_overlay.cpp
@@ -286,8 +286,8 @@ void FeOverlay::style_init()
 {
 	// Defaults to the first uiColorTokens value, which is the class blue
 	sf::Color col;
-	if ( !hex_to_color( m_feSettings.get_info( FeSettings::UIColor ), col ))
-		hex_to_color( FeSettings::uiColorTokens[ FE_DEFAULT_UI_COLOR_TOKEN ], col );
+	if ( !str_to_color( m_feSettings.get_info( FeSettings::UIColor ), col ))
+		str_to_color( FeSettings::uiColorTokens[ FE_DEFAULT_UI_COLOR_TOKEN ], col );
 	style_init( col );
 }
 
@@ -1544,7 +1544,7 @@ int FeOverlay::display_config_dialog(
 						if ( refresh_colour )
 						{
 							sf::Color col;
-							hex_to_color( FeSettings::uiColorTokens[ c.sel ], col );
+							str_to_color( FeSettings::uiColorTokens[ c.sel ], col );
 
 							style_init( col );
 							theme_letterbox( letterbox_top );

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -273,24 +273,24 @@ const char *FeSettings::startupDispTokens[] =
 
 std::vector<std::string> FeSettings::uiColorTokens =
 {
-	"#4400BB",
-	"#2850A0", // default
-	"#00BBFF",
-	"#00C3AA",
-	"#00CC44",
-	"#88CC33",
-	"#CCCC33",
-	"#FFCC00",
-	"#FF8800",
-	"#996622",
-	"#CC4411",
-	"#BB0011",
-	"#FF4488",
-	"#BB22BB",
-	"#8822BB",
-	"#444444",
-	"#797979",
-	"#BBBBBB",
+	"68,0,187",
+	"40,80,160", // default
+	"0,187,255",
+	"0,195,170",
+	"0,204,68",
+	"136,204,51",
+	"204,204,51",
+	"255,204,0",
+	"255,136,0",
+	"153,102,34",
+	"204,68,17",
+	"187,0,17",
+	"255,68,136",
+	"187,34,187",
+	"136,34,187",
+	"68,68,68",
+	"121,121,121",
+	"187,187,187",
 };
 
 std::vector<std::string> FeSettings::uiColorDispTokens =
@@ -3348,8 +3348,12 @@ bool FeSettings::set_info( int index, const std::string &value )
 		break;
 
 	case UIColor:
-		m_ui_color = value;
+	{
+		sf::Color col;
+		if ( str_to_color( value, col ) )
+			color_to_rgb( col, m_ui_color );
 		break;
+	}
 
 	default:
 		return false;

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -1990,18 +1990,46 @@ std::string get_focus_process()
 	return retval;
 }
 
-bool hex_to_color( std::string hex, sf::Color &dest_color )
+bool str_to_color( const std::string &str, sf::Color &col )
 {
-	try
-	{
-		std::string h = ( hex[0] == '#' ) ? hex.substr(1) : hex;
-		dest_color = sf::Color( std::stoul( "0x" + h + "FF", nullptr, 16 ) );
-		return true;
-	}
-	catch ( ... )
-	{
+	if ( rgb_to_color( str, col ) ) return true;
+	if ( hex_to_color( str, col ) ) return true;
+	return false;
+}
+
+bool rgb_to_color( const std::string &str, sf::Color &col )
+{
+	std::smatch m;
+	if ( !std::regex_search( str, m, std::regex( "^(\\d{1,3})[, ]+(\\d{1,3})[, ]+(\\d{1,3})$" ) ) )
 		return false;
-	}
+
+	col = sf::Color( as_int( m[1].str() ), as_int( m[2].str() ), as_int( m[3].str() ) );
+	return true;
+}
+
+bool hex_to_color( const std::string &str, sf::Color &col )
+{
+	std::smatch m;
+	if ( !std::regex_search( str, m, std::regex( "^#?([0-9A-F]{6})$" ) ) )
+		return false;
+
+	col = sf::Color( std::stoul( "0x" + m[1].str() + "FF", nullptr, 16 ) );
+	return true;
+}
+
+void color_to_rgb( const sf::Color &col, std::string &str )
+{
+	str = as_str( col.r ) + "," + as_str( col.g ) + "," + as_str( col.b );
+}
+
+void color_to_hex( const sf::Color &col, std::string &str )
+{
+	std::stringstream hex;
+	hex << "#"
+		<< std::hex << std::setw(2) << std::setfill('0') << (int)col.r
+		<< std::hex << std::setw(2) << std::setfill('0') << (int)col.g
+		<< std::hex << std::setw(2) << std::setfill('0') << (int)col.b;
+	str = hex.str();
 }
 
 int get_token_index( const char *tokens[], std::string &token )

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -422,12 +422,20 @@ void hide_console();
 
 #endif
 
-//
-// Hex string to sf::Color
-// - On invalid hex the dest_color will not be changed
-// - Returns true on success
-//
-bool hex_to_color( std::string hex, sf::Color &dest_color );
+// Auto string to sf::Color
+bool str_to_color( const std::string &str, sf::Color &col );
+
+// rgb string to sf::Color
+bool rgb_to_color( const std::string &str, sf::Color &col );
+
+// hex string to sf::Color
+bool hex_to_color( const std::string &str, sf::Color &col );
+
+// sf::Color to rgb string
+void color_to_rgb( const sf::Color &col, std::string &str );
+
+// sf::Color to hex string
+void color_to_hex( const sf::Color &col, std::string &str );
 
 //
 // Return index of token in tokens, or -1 if not found


### PR DESCRIPTION
- Fixed bug where empty `ui_color` config results in `black` gui
- Config now uses `rgb` format, but still accepts `hex` (will update to `rgb` on save)
- Changed to match API, which uses `rgb` throughout