### PR TITLE
Add get_general_config method

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -38,6 +38,7 @@
    -  [`fe.path_expand()`](#fepath_expand)
    -  [`fe.path_test()`](#fepath_test)
    -  [`fe.get_file_mtime()`](#feget_file_mtime-) 🔶
+   -  [`fe.get_general_config()`](#feget_general_config) 🔶
    -  [`fe.get_config()`](#feget_config)
    -  [`fe.get_text()`](#feget_text)
    -  [`fe.get_url()`](#feget_url-) 🔶
@@ -1065,6 +1066,24 @@ Returns the modified time of the given file.
 **Return Value**
 
 -  An integer containing the GMT timestamp.
+
+---
+
+### `fe.get_general_config()` 🔶
+
+```squirrel
+fe.get_general_config()
+```
+
+Get the Attract-Mode general configuration settings.
+
+**Parameters**
+
+-  None.
+
+**Return Value**
+
+-  A table containing AM's `general` configuration settings.
 
 ---
 

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1121,6 +1121,7 @@ bool FeVM::on_new_layout()
 	fe.Func<const char* (*)(const char *)>(_SC("path_expand"), &FeVM::cb_path_expand);
 	fe.Func<bool (*)(const char *, int)>(_SC("path_test"), &FeVM::cb_path_test);
 	fe.Func<time_t (*)(const char *)>(_SC("get_file_mtime"), &FeVM::cb_get_file_mtime);
+	fe.Func<Table (*)()>(_SC("get_general_config"), &FeVM::cb_get_general_config);
 	fe.Func<Table (*)()>(_SC("get_config"), &FeVM::cb_get_config);
 	fe.Func<void (*)(const char *)>(_SC("signal"), &FeVM::cb_signal);
 	fe.Overload<void (*)(int, bool, bool)>(_SC("set_display"), &FeVM::cb_set_display);
@@ -2751,6 +2752,25 @@ const char *FeVM::cb_get_art( const char *art, int index_offset )
 const char *FeVM::cb_get_art( const char *art )
 {
 	return cb_get_art( art, 0, 0, AF_Default );
+}
+
+Sqrat::Table FeVM::cb_get_general_config()
+{
+	Sqrat::Table retval;
+	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
+	FeVM *fev = (FeVM *)sq_getforeignptr( vm );
+	FeSettings *fes = fev->m_feSettings;
+
+	int i = 0;
+	while ( FeSettings::configSettingStrings[i] != NULL )
+	{
+		std::string key = FeSettings::configSettingStrings[i];
+		std::string value = fes->get_info( i );
+		retval.SetValue( key.c_str(), value.c_str() );
+		i++;
+	}
+
+	return retval;
 }
 
 Sqrat::Table FeVM::cb_get_config()

--- a/src/fe_vm.hpp
+++ b/src/fe_vm.hpp
@@ -254,6 +254,7 @@ public:
 	static const char *cb_get_art( const char *,int,int);
 	static const char *cb_get_art( const char *,int);
 	static const char *cb_get_art( const char *);
+	static Sqrat::Table cb_get_general_config();
 	static Sqrat::Table cb_get_config();
 	static void cb_signal( const char * );
 	static void cb_set_display( int, bool, bool );


### PR DESCRIPTION
New method `get_general_confg` returns table containing `attract.cfg` `general` section.

Provides direct access to useful internal config.