### PR TITLE
Fix per_display config parameters not updating

### DIFF
--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1410,6 +1410,12 @@ void FeVM::on_transition(
 			itr != worklist.end(); )
 		{
 			set_for_callback( *(*itr) );
+
+  			// Update per_display layout params when transitioning to a new list
+			// Only for layout callbacks (not plugins)
+			if ( t == ToNewList && (*itr)->m_sid < 0 )
+				m_feSettings->load_layout_params();
+
 			bool keep=false;
 			try
 			{


### PR DESCRIPTION
`per_display` config parameters were not updating when navigating between displays with the same layout assigned.

Test by navigating through several displays (also displays menu) using this layout:
( set test in Configure Layout to some unique numbers )
```cpp
class UserConfig </ help="Description" />
{
  </ label="Test", order=1, per_display=true /> test = "0"
}

local test = fe.add_text( "", 0, 0, flw, flh )
test.msg = fe.get_config()["test"]

fe.add_transition_callback( "on_transition" )
function on_transition( ttype, var, ttime )
{
  switch( ttype )
  {
    case Transition.ToNewList:
      test.msg = fe.get_config()["test"]
      break
  }
}
```