### PR TITLE
Rename Selection Restricted To Bounded

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -1680,10 +1680,10 @@ The class representing the listbox in Attract-Mode. Instances of this class are 
    -  `Align.MiddleRight`
    -  The last 3 alignment modes have the same function as the first 3, but they are more accurate. The first 3 modes are preserved for compatibility.
 -  `sel_mode` 🔶 - Get/set the selection mode. Controls how the listbox behaves when navigating. Can be one of the following values:
-   -  `Selection.Static` (default) - The selection remains at the `sel_row` (middle by default) while the list scrolls.
-   -  `Selection.Moving` - The selection moves freely, and the list scrolls when the `sel_margin` is reached.
-   -  `Selection.Restricted` - Identical to `Selection.Moving`, except `sel_row` is prevented from entering the `sel_margin` when the list edges are reached.
-   -  `Selection.Paged` - The selection moves freely, and the list scrolls _in pages_ when the `sel_margin` is reached.
+   -  `Selection.Static` (default) - The selection remains fixed at the `sel_row` (middle by default) while the list scrolls.
+   -  `Selection.Moving` - The selection moves freely, and the list scrolls when the `sel_margin` is reached. When the list edge is reached the selection enters the margin.
+   -  `Selection.Bounded` - Identical to `Selection.Moving` except the selection is always bounded by the margin.
+   -  `Selection.Paged` - The selection moves freely until it reaches the `sel_margin`, at which point the list scrolls _one page_ and the selection resets to the opposite margin.
 -  `sel_margin` 🔶 - Get/set the selection margin for `Selection.Moving` and `Selection.Paged` modes. The list will scroll when the selection is this many rows away from the edges.
 -  `sel_row` 🔶 - Get/set the index of the row that is currently selected, with respect to `sel_margin` and `list_size`. Has no effect in `Selection.Paged` mode. Defaults to the middle row.
 -  `font` - Get/set the filename of the font used for this listbox. If not set default font is used.

--- a/src/fe_listbox.cpp
+++ b/src/fe_listbox.cpp
@@ -403,20 +403,20 @@ void FeListBox::refresh_selection()
 	switch ( m_mode )
 	{
 		case Moving:
-		case Restricted:
+		case Bounded:
 		{
 			int margin = get_selection_margin();
 			int window_start = m_list_start_offset;
 			int window_end = window_start + display_rows - 1;
-			bool is_restricted = m_mode == Restricted;
+			bool is_bounded = m_mode == Bounded;
 
-			if ( list_size > display_rows || is_restricted )
+			if ( list_size > display_rows || is_bounded )
 			{
 				if ( sel < window_start + margin )
 				{
 					// Scroll the list up
 					m_list_start_offset = sel - margin;
-					if ( !is_restricted ) m_list_start_offset = std::max( 0, m_list_start_offset );
+					if ( !is_bounded ) m_list_start_offset = std::max( 0, m_list_start_offset );
 				}
 				else if ( sel > window_end - margin )
 				{
@@ -427,7 +427,7 @@ void FeListBox::refresh_selection()
 
 					// Scroll the list down
 					m_list_start_offset = sel - down_margin;
-					if ( !is_restricted ) m_list_start_offset = std::min( list_size - display_rows, m_list_start_offset );
+					if ( !is_bounded ) m_list_start_offset = std::min( list_size - display_rows, m_list_start_offset );
 				}
 			}
 
@@ -526,11 +526,11 @@ void FeListBox::refresh_list()
 	switch ( m_mode )
 	{
 		case Moving:
-		case Restricted:
+		case Bounded:
 		{
 			// Maintain m_selected_row on list change (if possible)
 			int goal_sel_row = m_selected_row;
-			bool is_restricted = m_mode == Restricted;
+			bool is_bounded = m_mode == Bounded;
 
 			// When using row alignment, m_selected_row will be changed to align the list
 			int empty_rows = rows - size;
@@ -550,7 +550,7 @@ void FeListBox::refresh_list()
 				}
 			}
 
-			int margin = is_restricted ? get_selection_margin() : 0;
+			int margin = is_bounded ? get_selection_margin() : 0;
 			int ma = -margin;
 			int mb = size - rows + margin;
 

--- a/src/fe_listbox.hpp
+++ b/src/fe_listbox.hpp
@@ -44,7 +44,7 @@ public:
 		Static=0,
 		Moving=1,
 		Paged=2,
-		Restricted=3
+		Bounded=3
 	};
 	// Constructor for use in scripts.  sets m_scripted to true
 	FeListBox( FePresentableParent &p, int x, int y, int w, int h );

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -670,7 +670,7 @@ bool FeVM::on_new_layout()
 			.Const( _SC("Static"), FeListBox::Static )
 			.Const( _SC("Moving"), FeListBox::Moving )
 			.Const( _SC("Paged"), FeListBox::Paged )
-			.Const( _SC("Restricted"), FeListBox::Restricted )
+			.Const( _SC("Bounded"), FeListBox::Bounded )
 			)
 		;
 


### PR DESCRIPTION
Just a simple rename: `Selection.Restricted` to `Selection.Buffered`
Like a train "Buffer Stop", since it's stopping the selection proceeding along the "track".
"Restricted" sounds like a movie rating.