### PR TITLE
Create Shaders from Strings

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -19,6 +19,7 @@
    -  [`fe.add_listbox()`](#feadd_listbox)
    -  [`fe.add_rectangle()`](#feadd_rectangle-) 🔶
    -  [`fe.add_shader()`](#feadd_shader)
+   -  [`fe.compile_shader()`](#fecompile_shader-) 🔶
    -  [`fe.add_sound()`](#feadd_sound)
    -  [`fe.add_music()`](#feadd_music-) 🔶
    -  [`fe.add_ticks_callback()`](#feadd_ticks_callback)
@@ -434,7 +435,7 @@ fe.add_shader( type, file1 )
 fe.add_shader( type )
 ```
 
-Add a GLSL shader (vertex and/or fragment) for use in the layout.
+Compile a GLSL shader from the given file(s) for use in the layout. Also see [`fe.compile_shader()`](#fecompile_shader-).
 
 **Parameters**
 
@@ -642,6 +643,32 @@ The `transition_time` parameter passed to the transition function is the amount 
 The transition function must return a boolean value. It should return `true` if a redraw is required, in which case Attract-Mode will redraw the screen and immediately call the transition function again with an updated `transition_time`.
 
 **_The transition function must eventually return `false` to notify Attract-Mode that the transition effect is done, allowing the normal operation of the frontend to proceed._**
+
+---
+
+### `fe.compile_shader()` 🔶
+
+```squirrel
+fe.compile_shader( type, shader1, shader2 )
+fe.compile_shader( type, shader1 )
+fe.compile_shader( type )
+```
+
+Compile a GLSL shader from the given shader code for use in the layout. Also see [`fe.add_shader()`](#feadd_shader).
+
+**Parameters**
+
+-  `type` - The type of shader to add. Can be one of the following values:
+   -  `Shader.VertexAndFragment` - Add a combined vertex and fragment shader
+   -  `Shader.Vertex` - Add a vertex shader
+   -  `Shader.Fragment` - Add a fragment shader
+   -  `Shader.Empty` - Add an empty shader. An object's shader property can be set to an empty shader to stop using a shader on that object where one was set previously.
+-  `shader1` - A string containing shader code. For the VertexAndFragment type, this should be the vertex shader.
+-  `shader2` - This parameter is only used with the VertexAndFragment type, and should be a string containing the fragment shader code.
+
+**Return Value**
+
+-  An instance of the class [`fe.Shader`](#feshader) which can be used to interact with the added shader.
 
 ---
 
@@ -1456,7 +1483,7 @@ The class representing an image in Attract-Mode. Instances of this class are ret
 -  `video_time` - Get the time that the video is current at (in milliseconds).
 -  `preserve_aspect_ratio` - Get/set whether the aspect ratio from the source image is to be preserved. Default value is `false`.
 -  `file_name` - _[image & artwork only]_ Get/set the name of the image/video file being shown. If you set this on an artwork or a dynamic image object it will get reset the next time the user changes the game selection. If file_name is contained in an archive, this string should be formatted: "<archive_name>|<filename>".
--  `shader` - Get/set the GLSL shader for this image. This can only be set to an instance of the class [`fe.Shader`](#feshader), see [`fe.add_shader()`](#feadd_shader).
+-  `shader` - Get/set the GLSL shader for this image. This can only be set to an instance of the class [`fe.Shader`](#feshader).
 -  `trigger` - Get/set the transition that triggers updates of this artwork/ dynamic image. Can be set to `Transition.ToNewSelection` or `Transition.EndNavigation`. Default value is `Transition.ToNewSelection`.
 -  `smooth` - Get/set whether the image is to be smoothed. Default value can be configured in `attract.cfg`.
 -  `zorder` - Get/set the Image's order in the applicable draw list. Objects with a lower zorder are drawn first, so that when objects overlap, the one with the higher zorder is drawn on top. Default value is `0`.
@@ -1593,7 +1620,7 @@ The class representing a text label in Attract-Mode. Instances of this class are
 -  `first_line_hint` 🔶 - Get/set the line in the formatted text that is shown as first line in the text object
 -  `font` - Get/set the filename of the font used for this text. If not set default font is used.
 -  `margin` - Get/set the margin spacing in pixels to sides of the text. Default value is `-1` which calculates the margin based on the `char_size`.
--  `shader` - Get/set the GLSL shader for this text. This can only be set to an instance of the class [`fe.Shader`](#feshader), see [`fe.add_shader()`](#feadd_shader).
+-  `shader` - Get/set the GLSL shader for this text. This can only be set to an instance of the class [`fe.Shader`](#feshader).
 -  `zorder` - Get/set the Text's order in the applicable draw list. Objects with a lower zorder are drawn first, so that when objects overlap, the one with the higher zorder is drawn on top. Default value is `0`.
 
 **Member Functions**
@@ -1689,7 +1716,7 @@ The class representing the listbox in Attract-Mode. Instances of this class are 
 -  `font` - Get/set the filename of the font used for this listbox. If not set default font is used.
 -  `margin` - Get/set the margin spacing in pixels to sides of the text. Default value is `-1` which calculates the margin based on the .char_size.
 -  `format_string` - Get/set the format for the text to display in each list entry. [_Magic Tokens_](#magic-tokens) can be used here. If empty, game titles will be displayed (i.e. the same behaviour as if set to `"[Title]"`). Default is an empty value.
--  `shader` - Get/set the GLSL shader for this listbox. This can only be set to an instance of the class [`fe.Shader`](#feshader), see [`fe.add_shader()`](#feadd_shader).
+-  `shader` - Get/set the GLSL shader for this listbox. This can only be set to an instance of the class [`fe.Shader`](#feshader).
 -  `zorder` - Get/set the listbox's order in the applicable draw list. Objects with a lower zorder are drawn first, so that when objects overlap, the one with the higher zorder is drawn on top. Default value is `0`.
 
 **Member Functions**
@@ -1759,7 +1786,7 @@ The class representing a rectangle in Attract-Mode. Instances of this class are 
 -  `corner_ratio_x` - Get/set the corner x radius as a fraction of the width. Range is `[0.0...0.5]`. Default value is `0.0`.
 -  `corner_ratio_y` - Get/set the corner y radius as a fraction of the height. Range is `[0.0...0.5]`. Default value is `0.0`.
 -  `corner_points` - Get/set the number of points used to draw the corner radius. More points produce smooth curves, while fewer points result in flat bevels. Range is `[1...32]`. Default value is `12`.
--  `shader` - Get/set the GLSL shader for this rectangle. This can only be set to an instance of the class [`fe.Shader`](#feshader), see [`fe.add_shader()`](#feadd_shader).
+-  `shader` - Get/set the GLSL shader for this rectangle. This can only be set to an instance of the class [`fe.Shader`](#feshader).
 -  `zorder` - Get/set the rectangles's order in the applicable draw list. Objects with a lower zorder are drawn first, so that when objects overlap, the one with the higher zorder is drawn on top. Default value is `0`.
 -  `blend_mode` - Get/set the blend mode for this rectangle. Can have one of the following values:
    -  `BlendMode.Alpha`
@@ -1834,7 +1861,7 @@ The class representing an audio track. Instances of this class are returned by t
 
 ### `fe.Shader`
 
-The class representing a GLSL shader. Instances of this class are returned by the [`fe.add_shader()`](#feadd_shader) function. This class cannot be otherwise instantiated in a script.
+The class representing a GLSL shader. Instances of this class are returned by the [`fe.add_shader()`](#feadd_shader) and [`fe.compile_shader()`](#fecompile_shader-) functions. This class cannot be otherwise instantiated in a script.
 
 **Properties**
 

--- a/src/fe_present.hpp
+++ b/src/fe_present.hpp
@@ -199,6 +199,7 @@ protected:
 	FeSound *add_sound(const char *n);
 	FeMusic *add_music(const char *n);
 	FeShader *add_shader(FeShader::Type type, const char *shader1, const char *shader2);
+	FeShader *compile_shader(FeShader::Type type, const char *shader1, const char *shader2);
 	float get_layout_width() const;
 	float get_layout_height() const;
 	int get_base_rotation() const;

--- a/src/fe_shader.cpp
+++ b/src/fe_shader.cpp
@@ -31,34 +31,55 @@ FeShader::FeShader()
 {
 }
 
-bool FeShader::load( sf::InputStream &vert_shader,
-		sf::InputStream &frag_shader )
+bool FeShader::load( sf::InputStream &vert, sf::InputStream &frag )
 {
 	m_type = VertexAndFragment;
-	return m_shader.loadFromStream( vert_shader, frag_shader );
+	return m_shader.loadFromStream( vert, frag );
 }
 
-bool FeShader::load( sf::InputStream &sh,
-		Type t )
+bool FeShader::load( sf::InputStream &sh, Type t )
 {
 	m_type = t;
-	return m_shader.loadFromStream( sh,
-		(t == Fragment) ? sf::Shader::Type::Fragment : sf::Shader::Type::Vertex );
+	sf::Shader::Type type = (t == Fragment) ? sf::Shader::Type::Fragment : sf::Shader::Type::Vertex;
+	return m_shader.loadFromStream( sh, type );
 }
 
-bool FeShader::load( const std::string &vert_shader,
-		const std::string &frag_shader )
+bool FeShader::load( const std::string &vert, const std::string &frag )
+{
+	if ( !file_exists( vert ) ) {
+		FeLog() << " ! Cannot find shader file: " << vert << std::endl;
+		return false;
+	}
+	if ( !file_exists( frag ) ) {
+		FeLog() << " ! Cannot find shader file: " << frag << std::endl;
+		return false;
+	}
+	m_type = VertexAndFragment;
+	return m_shader.loadFromFile( vert, frag );
+}
+
+bool FeShader::load( const std::string &sh, Type t )
+{
+	if ( !file_exists( sh ) ) {
+		FeLog() << " ! Cannot find shader file: " << sh << std::endl;
+		return false;
+	}
+	m_type = t;
+	sf::Shader::Type type = (t == Fragment) ? sf::Shader::Type::Fragment : sf::Shader::Type::Vertex;
+	return m_shader.loadFromFile( sh, type );
+}
+
+bool FeShader::loadFromMemory( const std::string &vert, const std::string &frag )
 {
 	m_type = VertexAndFragment;
-	return m_shader.loadFromFile( vert_shader, frag_shader );
+	return m_shader.loadFromMemory( vert, frag );
 }
 
-bool FeShader::load( const std::string &sh,
-		Type t )
+bool FeShader::loadFromMemory( const std::string &sh, Type t )
 {
 	m_type = t;
-	return m_shader.loadFromFile( sh,
-		(t == Fragment) ? sf::Shader::Type::Fragment : sf::Shader::Type::Vertex );
+	sf::Shader::Type type = (t == Fragment) ? sf::Shader::Type::Fragment : sf::Shader::Type::Vertex;
+	return m_shader.loadFromMemory( sh, type );
 }
 
 void FeShader::set_param( const char *name, float x )

--- a/src/fe_shader.hpp
+++ b/src/fe_shader.hpp
@@ -40,9 +40,10 @@ public:
 	FeShader();
 	bool load( sf::InputStream &vert, sf::InputStream &frag );
 	bool load( sf::InputStream &sh, Type t );
-
 	bool load( const std::string &vert, const std::string &frag );
 	bool load( const std::string &sh, Type t );
+	bool loadFromMemory( const std::string &vert, const std::string &frag );
+	bool loadFromMemory( const std::string &sh, Type t );
 
 	void set_param( const char *name, float x );
 	void set_param( const char *name, float x, float y );

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -32,6 +32,7 @@
 #include "nowide/convert.hpp"
 #include "nowide/stat.hpp"
 #include <sstream>
+#include <fstream>
 #include <algorithm>
 #include <cctype>
 #include <cstring>
@@ -281,6 +282,19 @@ bool file_exists( const std::string &file )
 bool directory_exists( const std::string &file )
 {
 	return check_path( file ) & FeVM::IsDirectory;
+}
+
+bool get_file_content( const std::string &file, std::string &output )
+{
+	std::ifstream f( file, std::ios::binary );
+	if ( !f.is_open() )
+		return false;
+
+	std::stringstream buffer;
+	buffer << f.rdbuf();
+	f.close();
+	output = buffer.str();
+	return true;
 }
 
 int check_path( const std::string &path )

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -202,6 +202,9 @@ bool file_exists( const std::string &file );
 // return true if specified path is an existing directory
 bool directory_exists( const std::string &file );
 
+// get the contents of the given file, return true on success
+bool get_file_content( const std::string &file, std::string &output );
+
 // Check if provided path exists and whether it's a file or a directory
 // Returns one of the following: IsFile, IsDirectory, IsNotFound
 int check_path( const std::string &file );

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1099,6 +1099,9 @@ bool FeVM::on_new_layout()
 	fe.Overload<FeShader* (*)(int, const char *, const char *)>(_SC("add_shader"), &FeVM::cb_add_shader);
 	fe.Overload<FeShader* (*)(int, const char *)>(_SC("add_shader"), &FeVM::cb_add_shader);
 	fe.Overload<FeShader* (*)(int)>(_SC("add_shader"), &FeVM::cb_add_shader);
+	fe.Overload<FeShader* (*)(int, const char *, const char *)>(_SC("compile_shader"), &FeVM::cb_compile_shader);
+	fe.Overload<FeShader* (*)(int, const char *)>(_SC("compile_shader"), &FeVM::cb_compile_shader);
+	fe.Overload<FeShader* (*)(int)>(_SC("compile_shader"), &FeVM::cb_compile_shader);
 	fe.Overload<void (*)(const char *)>(_SC("add_ticks_callback"), &FeVM::cb_add_ticks_callback);
 	fe.Overload<void (*)(Object, const char *)>(_SC("add_ticks_callback"), &FeVM::cb_add_ticks_callback);
 	fe.Overload<void (*)(const char *)>(_SC("add_transition_callback"), &FeVM::cb_add_transition_callback);
@@ -2366,6 +2369,27 @@ FeShader* FeVM::cb_add_shader( int type, const char *shader1 )
 FeShader* FeVM::cb_add_shader( int type )
 {
 	return cb_add_shader( type, NULL, NULL );
+}
+
+FeShader* FeVM::cb_compile_shader( int type, const char *shader1, const char *shader2 )
+{
+	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
+	FeVM *fev = (FeVM *)sq_getforeignptr( vm );
+
+	return fev->compile_shader( (FeShader::Type)type, shader1, shader2 );
+	//
+	// We assume the script will keep a reference to the shader
+	//
+}
+
+FeShader* FeVM::cb_compile_shader( int type, const char *shader1 )
+{
+	return cb_compile_shader( type, shader1, NULL );
+}
+
+FeShader* FeVM::cb_compile_shader( int type )
+{
+	return cb_compile_shader( type, NULL, NULL );
 }
 
 void FeVM::cb_add_ticks_callback( Sqrat::Object obj, const char *slot )

--- a/src/fe_vm.hpp
+++ b/src/fe_vm.hpp
@@ -204,6 +204,9 @@ public:
 	static FeShader *cb_add_shader(int, const char *, const char *);
 	static FeShader *cb_add_shader(int, const char *);
 	static FeShader *cb_add_shader(int);
+	static FeShader *cb_compile_shader(int, const char *, const char *);
+	static FeShader *cb_compile_shader(int, const char *);
+	static FeShader *cb_compile_shader(int);
 	static void cb_add_ticks_callback( Sqrat::Object, const char *);
 	static void cb_add_ticks_callback(const char *);
 	static void cb_add_transition_callback( Sqrat::Object, const char *);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,6 +120,9 @@ int main(int argc, char *argv[])
 	fe_print_version();
 	FeLog() << std::endl;
 
+	// Redirect SFML error buffer to FeLog
+	sf::err().rdbuf(FeLog().rdbuf());
+
 	if ( !sf::Shader::isAvailable() )
 	{
 		FeLog() << "Error, Attract-Mode Plus requires shader support."  << std::endl;


### PR DESCRIPTION
- Add `fe.compile_shader` method
  - Allows simple shaders to be kept inline (large shaders should ideally remain external)
  - Removes the need for custom pre-processors to create additional files (ie: resolving `#include` )
- Redirected SFML errors to `FeLog`
  - Now errors such as shader warnings print immediately rather than dumping on AM exit
- Fix crash on `add_shader` with empty filename string, now ensures `file_exists` first
  
```squirrel
local frag = "void main() { gl_FragColor = vec4(gl_TexCoord[0].xy, 0.0, 1.0); }"
local surf = fe.add_surface(0, 0, fe.layout.width, fe.layout.height)
surf.shader = fe.compile_shader(Shader.Fragment, frag)
```