### PR TITLE
Fix artwork zero index_offset bug

### DIFF
--- a/src/fe_image.cpp
+++ b/src/fe_image.cpp
@@ -692,7 +692,7 @@ void FeTextureContainer::set_vol( float vol )
 
 void FeTextureContainer::set_index_offset( int io, bool do_update )
 {
-	if ( m_index_offset != io )
+	if ( m_index_offset != io || m_file_name.empty() )
 	{
 		m_index_offset = io;
 
@@ -708,7 +708,7 @@ int FeTextureContainer::get_index_offset() const
 
 void FeTextureContainer::set_filter_offset( int fo, bool do_update )
 {
-	if ( m_filter_offset != fo )
+	if ( m_filter_offset != fo || m_file_name.empty() )
 	{
 		m_filter_offset = fo;
 


### PR DESCRIPTION
- Allow image to call `script_do_update` when `m_file_name` is empty
- This allows setting an `index_offset` to the zero (its initial value) to force an update
- Fixes #58
```squirrel
local art = fe.add_artwork("snap", 0, 0, 500, 500)
art.index_offset = 0
fe.log(format("%s = %d x %d", art.file_name, art.texture_width, art.texture_height))
// Now the art values are populated
```
Note: this is an intermediate fix, since it still requires `index_offset` to be set be populating.
A more thorough fix would require checking load state in *all* getters, and performing the update as necessary.