### PR TITLE
Replace-Attract-Mode-references

### DIFF
--- a/Compile.md
+++ b/Compile.md
@@ -37,7 +37,7 @@ These instructions assume that you have the GNU C/C++ compilers and basic build 
       -  libarchive (for .7z, .rar, .tar.gz and .tar.bz2 archive support).
       -  Libcurl (for network info/artwork scraping).
 
-2. Extract the Attract-Mode source to your system.
+2. Extract the Attract-Mode Plus source to your system.
 
 3. From the directory you extracted the source into, run:
 
@@ -53,7 +53,7 @@ These instructions assume that you have the GNU C/C++ compilers and basic build 
 
    This step will create the "attract" executable file.
 
-4. The final step is to actually copy the Attract-Mode executable and data to a location where they can be used. To install on a system-wide basis you should run:
+4. The final step is to actually copy the Attract-Mode Plus executable and data to a location where they can be used. To install on a system-wide basis you should run:
 
    ```sh
    sudo make install
@@ -61,9 +61,9 @@ These instructions assume that you have the GNU C/C++ compilers and basic build 
 
    This will copy the "attract" executable to `/usr/local/bin/` and default data to `/usr/local/share/attract/`.
 
-   For a single user install on Linux or FreeBSD, you can complete this step by copying the contents of the "config" directory from the Attract-Mode source directory to the location that you will use as your Attract-Mode config directory. By default, this config directory is located in `$HOME/.attract` on Linux/FreeBSD systems.
+   For a single user install on Linux or FreeBSD, you can complete this step by copying the contents of the "config" directory from the Attract-Mode Plus source directory to the location that you will use as your Attract-Mode Plus config directory. By default, this config directory is located in `$HOME/.attract` on Linux/FreeBSD systems.
 
-   NOTE: The Attract-Mode makefile tries to follow the GNU standards for specifying installation directories: https://www.gnu.org/prep/standards/html_node/Directory-Variables.html. If you want to change the location where Attract-Mode looks for its default data from `/usr/local/share/attract` you should change these values appropriately before running the `make` and `make install` commands.
+   NOTE: The Attract-Mode Plus makefile tries to follow the GNU standards for specifying installation directories: https://www.gnu.org/prep/standards/html_node/Directory-Variables.html. If you want to change the location where Attract-Mode Plus looks for its default data from `/usr/local/share/attract` you should change these values appropriately before running the `make` and `make install` commands.
 
 ---
 
@@ -84,9 +84,9 @@ These instructions assume that you have X Code installed.
    brew install pkg-config ffmpeg sfml libarchive
    ```
 
-3. Extract the Attract-Mode source to your system.
+3. Extract the Attract-Mode Plus source to your system.
 
-4. From the directory you extracted the Attract-Mode source into, run:
+4. From the directory you extracted the Attract-Mode Plus source into, run:
 
    ```sh
    make
@@ -94,7 +94,7 @@ These instructions assume that you have X Code installed.
 
    This step will create the "attract" executable file.
 
-5. The final step is to actually copy the Attract-Mode executable and data to the location where they will be used. You can run:
+5. The final step is to actually copy the Attract-Mode Plus executable and data to the location where they will be used. You can run:
 
    ```sh
    sudo make install
@@ -102,13 +102,13 @@ These instructions assume that you have X Code installed.
 
    to install on a system-wide basis. This will copy the 'attract' executable to `/usr/local/bin/` and data to `/usr/local/share/attract/`
 
-   If you prefer to do a single user install, you can complete this step by copying the contents of the "config" directory from the Attract-Mode source directory to the location that you will use as your Attract-Mode config directory. By default, this config directory is `$HOME/.attract` on OS X.
+   If you prefer to do a single user install, you can complete this step by copying the contents of the "config" directory from the Attract-Mode Plus source directory to the location that you will use as your Attract-Mode Plus config directory. By default, this config directory is `$HOME/.attract` on OS X.
 
 ---
 
 ## Windows (cross-compile)
 
-The recommended way to build Windows binaries for Attract-Mode is to cross compile on an OS that supports MXE http://mxe.cc such as Linux, FreeBSD or OS X.
+The recommended way to build Windows binaries for Attract-Mode Plus is to cross compile on an OS that supports MXE http://mxe.cc such as Linux, FreeBSD or OS X.
 
 1. Follow the steps in the mxe tutorial to set up mxe on your system: http://mxe.cc/#tutorial
 
@@ -124,7 +124,7 @@ The recommended way to build Windows binaries for Attract-Mode is to cross compi
    make MXE_TARGETS='x86_64-w64-mingw32.static' ffmpeg sfml libarchive curl
    ```
 
-3. Extract the Attract-Mode source to your system.
+3. Extract the Attract-Mode Plus source to your system.
 
 4. From the directory you extracted the source into, run the following:
 
@@ -132,7 +132,7 @@ The recommended way to build Windows binaries for Attract-Mode is to cross compi
    make CROSS=1 TOOLCHAIN=i686-w64-mingw32.static WINDOWS_STATIC=1
    ```
 
-   to build the 32-bit version of Attract-Mode. To build 64-bit, run:
+   to build the 32-bit version of Attract-Mode Plus. To build 64-bit, run:
 
    ```sh
    make CROSS=1 TOOLCHAIN=x86_64-w64-mingw32.static WINDOWS_STATIC=1
@@ -140,7 +140,7 @@ The recommended way to build Windows binaries for Attract-Mode is to cross compi
 
    This step will create the "attract.exe" executable file.
 
-5. Copy the contents of the config directory from the Attract-Mode source directory and the executable you just built into the same directory on your Windows-based system, and you should be ready to go!
+5. Copy the contents of the config directory from the Attract-Mode Plus source directory and the executable you just built into the same directory on your Windows-based system, and you should be ready to go!
 
 ---
 
@@ -166,12 +166,12 @@ The recommended way to build Windows binaries for Attract-Mode is to cross compi
    pacman -S git mingw-w64-x86_64-toolchain msys/make mingw64/mingw-w64-x86_64-sfml mingw64/mingw-w64-x86_64-ffmpeg mingw64/mingw-w64-x86_64-libarchive
    ```
 
-5. Clone and make Attract-Mode
+5. Clone and make Attract-Mode Plus
 
    ```sh
-   git clone https://github.com/mickelson/attract attract
+   git clone https://github.com/oomek/attractplus attract
    cd attract
    make
    ```
 
-   This builds a version of Attract-Mode with various .dll dependencies. To run the program, you will need to add `c:\msys64\mingw64\bin` to your path (for 64-bit systems) or copy the dependent .dlls from that directory into the same directory you will run Attract-Mode from.
+   This builds a version of Attract-Mode Plus with various .dll dependencies. To run the program, you will need to add `c:\msys64\mingw64\bin` to your path (for 64-bit systems) or copy the dependent .dlls from that directory into the same directory you will run Attract-Mode Plus from.

--- a/Layouts.md
+++ b/Layouts.md
@@ -79,26 +79,26 @@
 
 ## Overview
 
-The Attract-mode layout sets out what gets displayed to the user. Layouts consist of a `layout.nut` script file and a collection of related resources (images, other scripts, etc.) used by the script.
+The Attract-Mode Plus layout sets out what gets displayed to the user. Layouts consist of a `layout.nut` script file and a collection of related resources (images, other scripts, etc.) used by the script.
 
-Layouts are stored under the "layouts" subdirectory of the Attract-Mode config directory. Each layout is stored in its own separate subdirectory or archive file (Attract-Mode can read layouts and plugins directly from `.zip`, `.7z`, `.rar`, `.tar.gz`, `.tar.bz2` and `.tar` files).
+Layouts are stored under the "layouts" subdirectory of the Attract-Mode Plus config directory. Each layout is stored in its own separate subdirectory or archive file (Attract-Mode Plus can read layouts and plugins directly from `.zip`, `.7z`, `.rar`, `.tar.gz`, `.tar.bz2` and `.tar` files).
 
-Each layout can have one or more `layout*.nut` script files. The "Toggle Layout" command in Attract-Mode allows users to cycle between each of the `layout*.nut` script files located in the layout's directory. Attract-Mode remembers the last layout file toggled to for each layout and will go back to that same file the next time the layout is loaded. This allows for variations of a particular layout to be implemented and easily selected by the user (for example, a layout could provide a `layout.nut` for horizontal monitor orientations and a `layout-vert.nut` for vertical).
+Each layout can have one or more `layout*.nut` script files. The "Toggle Layout" command in Attract-Mode Plus allows users to cycle between each of the `layout*.nut` script files located in the layout's directory. Attract-Mode Plus remembers the last layout file toggled to for each layout and will go back to that same file the next time the layout is loaded. This allows for variations of a particular layout to be implemented and easily selected by the user (for example, a layout could provide a `layout.nut` for horizontal monitor orientations and a `layout-vert.nut` for vertical).
 
-The Attract-Mode screen saver and intro modes are really just special case layouts. The screensaver gets loaded after a user-configured period of inactivity, while the intro mode gets run when the frontend first starts and exits as soon as any action is triggered (for example if the user hits the select button). The screen saver script is located in the `screensaver.nut` file stored in the "screensaver" subdirectory. The intro script is located in the `intro.nut` file stored in the "intro" subdirectory.
+The Attract-Mode Plus screen saver and intro modes are really just special case layouts. The screensaver gets loaded after a user-configured period of inactivity, while the intro mode gets run when the frontend first starts and exits as soon as any action is triggered (for example if the user hits the select button). The screen saver script is located in the `screensaver.nut` file stored in the "screensaver" subdirectory. The intro script is located in the `intro.nut` file stored in the "intro" subdirectory.
 
-Plug-ins are similar to layouts in that they consist of at least one squirrel script file and a collection of related resources. Plug-ins are stored in the "plugins" subdirectory of the Attract-Mode config directory. Plug-ins can be a single ".nut" file stored in this subdirectory. They can also have their own separate subdirectory or archive file (in which case the script itself needs to be in a file called `plugin.nut`).
+Plug-ins are similar to layouts in that they consist of at least one squirrel script file and a collection of related resources. Plug-ins are stored in the "plugins" subdirectory of the Attract-Mode Plus config directory. Plug-ins can be a single ".nut" file stored in this subdirectory. They can also have their own separate subdirectory or archive file (in which case the script itself needs to be in a file called `plugin.nut`).
 
 ---
 
 ### Squirrel Language
 
-Attract-Mode's layouts are scripts written in the Squirrel programming language. Squirrel's standard `Blob`, `IO`, `Math`, `String` and `System` library functions are available for use in a script. For more information on programming in Squirrel and using its standard libraries, consult the Squirrel manuals:
+Attract-Mode Plus layouts are scripts written in the Squirrel programming language. Squirrel's standard `Blob`, `IO`, `Math`, `String` and `System` library functions are available for use in a script. For more information on programming in Squirrel and using its standard libraries, consult the Squirrel manuals:
 
 -  [Squirrel 3.0 Reference Manual](http://www.squirrel-lang.org/doc/squirrel3.html)
 -  [Squirrel 3.0 Standard Library Manual](http://www.squirrel-lang.org/doc/sqstdlib3.html)
 
-Also check out the Introduction to Squirrel on the Attract-Mode wiki:
+Also check out the Introduction to Squirrel on the wiki:
 
 -  https://github.com/mickelson/attract/wiki/Introduction-to-Squirrel-Programming
 
@@ -106,7 +106,7 @@ Also check out the Introduction to Squirrel on the Attract-Mode wiki:
 
 ### Language Extensions
 
-Attract-Mode includes the following home-brewed extensions to the squirrel language and standard libraries:
+Attract-Mode Plus includes the following home-brewed extensions to the squirrel language and standard libraries:
 
 -  A `zip_extract_archive( zipfile, filename )` function that will open a specified `zipfile` archive file and extract `filename` from it, returning the contents as a squirrel blob.
 -  A `zip_get_dir( zipfile )` function that will return an array of the filenames contained in the `zipfile` archive file.
@@ -117,7 +117,7 @@ Supported archive formats are: `.zip`, `.7z`, `.rar`, `.tar.gz`, `.tar.bz2` and 
 
 ### Frontend Binding
 
-All of the functions, objects and classes that Attract-Mode exposes to Squirrel are arranged under the `fe` table, which is bound to Squirrel's root table.
+All of the functions, objects and classes that Attract-Mode Plus exposes to Squirrel are arranged under the `fe` table, which is bound to Squirrel's root table.
 
 ```squirrel
 fe.add_image( "bg.png", 0, 0 )
@@ -183,7 +183,7 @@ The following _Magic Tokens_ are supported:
 
 #### Custom Magic Token Functions
 
-_Magic Tokens_ can also run user-defined functions in the form `[!token_function]`. When used, Attract-Mode will run the corresponding `token_function()` defined in the Squirrel "root table". The function may contain up to two parameters, and must return a string value to replace the _Magic Token_.
+_Magic Tokens_ can also run user-defined functions in the form `[!token_function]`. When used, Attract-Mode Plus will run the corresponding `token_function()` defined in the Squirrel "root table". The function may contain up to two parameters, and must return a string value to replace the _Magic Token_.
 
 -  `index_offset` - The offset (from the current selection) of the game.
 -  `filter_offset` - The offset (from the current filter) of the filter.
@@ -278,13 +278,13 @@ fe.add_image( name, x, y )
 fe.add_image( name, x, y, w, h )
 ```
 
-Adds an image or video to the end of Attract-Mode's draw list.
+Adds an image or video to the end of the draw list.
 
 The default blend mode for images is `BlendMode.Alpha`
 
 **Parameters**
 
--  `name` - The name of an image/video file to show. If a relative path is provided (i.e. `"bg.png"`) it is assumed to be relative to the current layout directory (or the plugin directory, if called from a plugin script). If a relative path is provided and the layout/plugin is contained in an archive, Attract-Mode will open the corresponding file stored inside of the archive. Supported image formats are: `PNG`, `JPEG`, `GIF`, `BMP` and `TGA`. Videos can be in any format supported by FFmpeg. One or more [_Magic Tokens_](#magic-tokens) can be used in the name, in which case Attract-Mode will automatically update the image/video file appropriately in response to user navigation. For example `"man/[Manufacturer]"` will load the file corresponding to the manufacturer's name from the man subdirectory of the layout/plugin (example: `"man/Konami.png"`). When Magic Tokens are used, the file extension specified in `name` is ignored (if present) and Attract-Mode will load any supported media file that matches the Magic Token.
+-  `name` - The name of an image/video file to show. If a relative path is provided (i.e. `"bg.png"`) it is assumed to be relative to the current layout directory (or the plugin directory, if called from a plugin script). If a relative path is provided and the layout/plugin is contained in an archive, Attract-Mode Plus will open the corresponding file stored inside of the archive. Supported image formats are: `PNG`, `JPEG`, `GIF`, `BMP` and `TGA`. Videos can be in any format supported by FFmpeg. One or more [_Magic Tokens_](#magic-tokens) can be used in the name, in which case Attract-Mode Plus will automatically update the image/video file appropriately in response to user navigation. For example `"man/[Manufacturer]"` will load the file corresponding to the manufacturer's name from the man subdirectory of the layout/plugin (example: `"man/Konami.png"`). When Magic Tokens are used, the file extension specified in `name` is ignored (if present) and Attract-Mode Plus will load any supported media file that matches the Magic Token.
 -  `x` - The x position of the image (in layout coordinates).
 -  `y` - The y position of the image (in layout coordinates).
 -  `w` - The width of the image (in layout coordinates). Default value is `0`, which enables `auto_width`.
@@ -304,13 +304,13 @@ fe.add_artwork( label, x, y )
 fe.add_artwork( label, x, y, w, h )
 ```
 
-Add an artwork to the end of Attract-Mode's draw list. The image/video displayed in an artwork is updated automatically whenever the user changes the game selection.
+Add an artwork to the end of the draw list. The image/video displayed in an artwork is updated automatically whenever the user changes the game selection.
 
 The default blend mode for artwork is `BlendMode.Alpha`
 
 **Parameters**
 
--  `label` - The label of the artwork to display. This should correspond to an artwork configured in Attract-Mode (artworks are configured per emulator in the config menu) or scraped using the scraper. Attract-Mode's standard artwork labels are: `"snap"`, `"marquee"`, `"flyer"`, `"wheel"`, and `"fanart"`.
+-  `label` - The label of the artwork to display. This should correspond to an artwork configured in Attract-Mode Plus (artworks are configured per emulator in the config menu) or scraped using the scraper. Standard artwork labels are: `"snap"`, `"marquee"`, `"flyer"`, `"wheel"`, and `"fanart"`.
 -  `x` - The x position of the artwork (in layout coordinates).
 -  `y` - The y position of the artwork (in layout coordinates).
 -  `w` - The width of the artwork (in layout coordinates). Default value is `0`, which enables `auto_width`.
@@ -329,7 +329,7 @@ fe.add_surface( w, h )
 fe.add_surface( x, y, w, h ) 🔶
 ```
 
-Add a surface to the end of Attract-Mode's draw list. A surface is an off-screen texture upon which you can draw other [`fe.Image`](#feadd_image), [`fe.Artwork`](#feadd_artwork), [`fe.Text`](#feadd_text), [`fe.Listbox`](#feadd_listbox) and [`fe.Surface`](#feadd_surface) objects. The resulting texture is treated as a static image by Attract-Mode which can in turn have image effects applied to it (`scale`, `position`, `pinch`, `skew`, `shaders`, etc) when it is drawn.
+Add a surface to the end of the draw list. A surface is an off-screen texture upon which you can draw other [`fe.Image`](#feadd_image), [`fe.Artwork`](#feadd_artwork), [`fe.Text`](#feadd_text), [`fe.Listbox`](#feadd_listbox) and [`fe.Surface`](#feadd_surface) objects. The resulting texture is treated as a static image by Attract-Mode Plus which can in turn have image effects applied to it (`scale`, `position`, `pinch`, `skew`, `shaders`, etc) when it is drawn.
 
 The default blend mode for surfaces is `BlendMode.Premultiplied`
 
@@ -352,7 +352,7 @@ The default blend mode for surfaces is `BlendMode.Premultiplied`
 fe.add_clone( img )
 ```
 
-Clone an image, artwork or surface object and add the clone to the back of Attract-Mode's draw list. The texture pixel data of the original and clone is shared as a result.
+Clone an image, artwork or surface object and add the clone to the back of the draw list. The texture pixel data of the original and clone is shared as a result.
 
 **Parameters**
 
@@ -370,11 +370,11 @@ Clone an image, artwork or surface object and add the clone to the back of Attra
 fe.add_text( msg, x, y, w, h )
 ```
 
-Add a text label to the end of Attract-Mode's draw list.
+Add a text label to the end of the draw list.
 
 **Parameters**
 
--  `msg` - The text to display. [_Magic Tokens_](#magic-tokens) can be used here, in which case Attract-Mode will dynamically update the msg in response to navigation.
+-  `msg` - The text to display. [_Magic Tokens_](#magic-tokens) can be used here, in which case Attract-Mode Plus will dynamically update the msg in response to navigation.
 -  `x` - The x coordinate of the top left corner of the text (in layout coordinates).
 -  `y` - The y coordinate of the top left corner of the text (in layout coordinates).
 -  `w` - The width of the text (in layout coordinates).
@@ -392,7 +392,7 @@ Add a text label to the end of Attract-Mode's draw list.
 fe.add_listbox( x, y, w, h )
 ```
 
-Add a listbox to the end of Attract-Mode's draw list.
+Add a listbox to the end of the draw list.
 
 **Parameters**
 
@@ -414,7 +414,7 @@ Add a listbox to the end of Attract-Mode's draw list.
 fe.add_rectangle( x, y, w, h )
 ```
 
-Add a rectangle to the end of Attract-Mode's draw list.
+Add a rectangle to the end of the draw list.
 
 **Parameters**
 
@@ -495,7 +495,7 @@ Compile a GLSL shader from the given file(s) for use in the layout. Also see [`f
 fe.add_sound( name )
 ```
 
-Add a sound file that can then be played by Attract-Mode. For short sounds, stored in RAM. For playing long audio tracks use [`fe.add_music()`](#feadd_music-).
+Add a sound file that can then be played by Attract-Mode Plus. For short sounds, stored in RAM. For playing long audio tracks use [`fe.add_music()`](#feadd_music-).
 
 **Parameters**
 
@@ -513,7 +513,7 @@ Add a sound file that can then be played by Attract-Mode. For short sounds, stor
 fe.add_music( name )
 ```
 
-Add an audio track that can then be played by Attract-Mode. For long audio tracks, streamed from disk. For playing short sounds use [`fe.add_sound()`](#feadd_sound).
+Add an audio track that can then be played by Attract-Mode Plus. For long audio tracks, streamed from disk. For playing short sounds use [`fe.add_sound()`](#feadd_sound).
 
 **Parameters**
 
@@ -642,9 +642,9 @@ The value of the `var` parameter passed to the transition function depends upon 
 
 The `transition_time` parameter passed to the transition function is the amount of time (in milliseconds) since the transition began.
 
-The transition function must return a boolean value. It should return `true` if a redraw is required, in which case Attract-Mode will redraw the screen and immediately call the transition function again with an updated `transition_time`.
+The transition function must return a boolean value. It should return `true` if a redraw is required, in which case Attract-Mode Plus will redraw the screen and immediately call the transition function again with an updated `transition_time`.
 
-**_The transition function must eventually return `false` to notify Attract-Mode that the transition effect is done, allowing the normal operation of the frontend to proceed._**
+**_The transition function must eventually return `false` to notify Attract-Mode Plus that the transition effect is done, allowing the normal operation of the frontend to proceed._**
 
 ---
 
@@ -739,7 +739,7 @@ Get the filename of an artwork for the selected game.
 
 **Parameters**
 
--  `label` - The label of the artwork to retrieve. This should correspond to an artwork configured in Attract-Mode (artworks are configured per emulator in the config menu) or scraped using the scraper. Attract-Mode's standard artwork labels are: `"snap"`, `"marquee"`, `"flyer"`, `"wheel"`, and `"fanart"`.
+-  `label` - The label of the artwork to retrieve. This should correspond to an artwork configured in Attract-Mode Plus (artworks are configured per emulator in the config menu) or scraped using the scraper. Standard artwork labels are: `"snap"`, `"marquee"`, `"flyer"`, `"wheel"`, and `"fanart"`.
 -  `index_offset` - The offset (from the current selection) of the game to retrieve the filename for. i.e. `-1` = previous game, `0` = current game, `1` = next game, and so on. Default value is `0`.
 -  `filter_offset` - The offset (from the current filter) of the filter containing the selection to retrieve the filename for. i.e. `-1` = previous filter, `0` = current filter. Default value is `0`.
 -  `flags` - Flags to control the filename that gets returned. Can be set
@@ -970,7 +970,7 @@ Loads a module (a "library" Squirrel script).
 
 **Parameters**
 
--  `name` - The name of the library module to load. This should correspond to a script file in the "modules" subdirectory of your Attract-Mode configuration (without the file extension).
+-  `name` - The name of the library module to load. This should correspond to a script file in the "modules" subdirectory of your Attract-Mode Plus configuration (without the file extension).
 
 **Return Value**
 
@@ -1104,7 +1104,7 @@ Returns the modified time of the given file.
 fe.get_general_config()
 ```
 
-Get the Attract-Mode general configuration settings.
+Get the Attract-Mode Plus general configuration settings.
 
 **Parameters**
 
@@ -1112,7 +1112,7 @@ Get the Attract-Mode general configuration settings.
 
 **Return Value**
 
--  A table containing AM's `general` configuration settings.
+-  A table containing the Attract-Mode Plus `general` configuration settings.
 
 ---
 
@@ -1201,7 +1201,7 @@ An instance of the [`fe.CurrentList`](#fecurrentlist) class and is where current
 
 ### `fe.image_cache`
 
-An instance of the [`fe.ImageCache`](#feimagecache) class and provides script access to Attract-Mode's internal image cache.
+An instance of the [`fe.ImageCache`](#feimagecache) class and provides script access to the internal image cache.
 
 ### `fe.overlay`
 
@@ -1209,7 +1209,7 @@ An instance of the [`fe.Overlay`](#feoverlay-1) class and is where overlay funct
 
 ### `fe.obj`
 
-Contains the Attract-Mode draw list. It is an array of [`fe.Image`](#feimage), [`fe.Text`](#fetext), [`fe.ListBox`](#felistbox), and [`fe.Rectangle`](#ferectangle-) instances.
+Contains the Attract-Mode Plus draw list. It is an array of [`fe.Image`](#feimage), [`fe.Text`](#fetext), [`fe.ListBox`](#felistbox), and [`fe.Rectangle`](#ferectangle-) instances.
 
 ### `fe.displays`
 
@@ -1225,19 +1225,19 @@ An array of [`fe.Monitor`](#femonitor) instances, and provides the mechanism for
 
 ### `fe.script_dir`
 
-When Attract-Mode runs a layout or plug-in script, `fe.script_dir` is set to the layout or plug-in's directory.
+When Attract-Mode Plus runs a layout or plug-in script, `fe.script_dir` is set to the layout or plug-in's directory.
 
 ### `fe.script_file`
 
-When Attract-Mode runs a layout or plug-in script, `fe.script_file` is set to the name of the layout or plug-in script file.
+When Attract-Mode Plus runs a layout or plug-in script, `fe.script_file` is set to the name of the layout or plug-in script file.
 
 ### `fe.module_dir`
 
-When Attract-Mode runs a module script, `fe.module_dir` is set to the module's directory.
+When Attract-Mode Plus runs a module script, `fe.module_dir` is set to the module's directory.
 
 ### `fe.nv`
 
-The `fe.nv` table can be used by layouts and plugins to store persistent values. The values in this table get saved by Attract-Mode whenever the layout changes and are saved to disk when Attract-Mode is shut down. `boolean`, `integer`, `float`, `string`, `array` and `table` values can be stored in this table.
+The `fe.nv` table can be used by layouts and plugins to store persistent values. The values in this table get saved by Attract-Mode Plus whenever the layout changes and are saved to disk when Attract-Mode Plus is shut down. `boolean`, `integer`, `float`, `string`, `array` and `table` values can be stored in this table.
 
 ---
 
@@ -1252,7 +1252,7 @@ This class is a container for global layout settings. The instance of this class
 -  `width` - Get/set the layout width. Default value is `ScreenWidth`.
 -  `height` - Get/set the layout height. Default value is `ScreenHeight`.
 -  `font` - Get/set the filename of the font which will be used for text and listbox objects in this layout.
--  `base_rotation` - Get the base orientation of Attract Mode which is set in General Settings. This property cannot be set from the script. This can be one of the following values:
+-  `base_rotation` - Get the base orientation of Attract-Mode Plus which is set in General Settings. This property cannot be set from the script. This can be one of the following values:
    -  `RotateScreen.None` (default)
    -  `RotateScreen.Right`
    -  `RotateScreen.Flip`
@@ -1295,14 +1295,14 @@ This class is a container for status information regarding the current display. 
 
 ### `fe.ImageCache`
 
-This class is a container for Attract-Mode's internal image cache. The instance of this class is the [`fe.image_cache`](#feimage_cache) object. This class cannot be otherwise instantiated in a script.
+This class is a container for the internal image cache. The instance of this class is the [`fe.image_cache`](#feimage_cache) object. This class cannot be otherwise instantiated in a script.
 
 **Properties**
 
 -  `count` - Get the number of images currently in the cache.
 -  `size` - Get the current size of the image cache (in bytes).
 -  `max_size` - Get the (user configured) maximum size of the image cache (in bytes).
--  `bg_load` - Get/set whether images are to be loaded on a background thread. Setting to `true` might make Attract-Mode animations smoother, but can cause a slight flicker as images get loaded. Default value is `false`.
+-  `bg_load` - Get/set whether images are to be loaded on a background thread. Setting to `true` might make Attract-Mode Plus animations smoother, but can cause a slight flicker as images get loaded. Default value is `false`.
 
 **Member Functions**
 
@@ -1326,7 +1326,7 @@ This class is a container for overlay functionality. The instance of this class 
 
 -  `set_custom_controls( caption_text, options_listbox )`
 -  `set_custom_controls( caption_text )`
--  `set_custom_controls()` - Tells the frontend that the layout will provide custom controls for displaying overlay menus such as the exit dialog, displays menu, etc. The `caption_text` parameter is the FeText object that the frontend end should use to display the overlay caption (i.e. `"Exit Attract-Mode?"`). The `options_listbox` parameter is the FeListBox object that the frontend should use to display the overlay options.
+-  `set_custom_controls()` - Tells the frontend that the layout will provide custom controls for displaying overlay menus such as the exit dialog, displays menu, etc. The `caption_text` parameter is the FeText object that the frontend end should use to display the overlay caption (i.e. `"Exit Attract-Mode Plus?"`). The `options_listbox` parameter is the FeListBox object that the frontend should use to display the overlay options.
 -  `clear_custom_controls()` - Tell the frontend that the layout will NOT do any custom control handling for overlay menus. This will result in the frontend using its built-in default menus instead for overlays.
 -  `list_dialog( options, title, default_sel, cancel_sel )`
 -  `list_dialog( options, title, default_sel )`
@@ -1392,7 +1392,7 @@ This class is a container for information about the available filters. Instances
 
 ### `fe.Monitor`
 
-This class represents a monitor in Attract-Mode, and provides the interface to the extra monitors in a multi-monitor setup. Instances of this class are contained in the [`fe.monitors`](#femonitors) array. This class cannot otherwise be instantiated in a script.
+This class represents a monitor in Attract-Mode Plus, and provides the interface to the extra monitors in a multi-monitor setup. Instances of this class are contained in the [`fe.monitors`](#femonitors) array. This class cannot otherwise be instantiated in a script.
 
 **Properties**
 
@@ -1412,14 +1412,14 @@ This class represents a monitor in Attract-Mode, and provides the interface to t
 
 **Notes**
 
--  As of this writing, multiple monitor support has not been implemented for the `OS X` version of Attract-Mode.
+-  As of this writing, multiple monitor support has not been implemented for the `OS X` version of Attract-Mode Plus.
 -  The first entry in the [`fe.monitors`](#femonitors) array is always the _primary_ display for the system.
 
 ---
 
 ### `fe.Image`
 
-The class representing an image in Attract-Mode. Instances of this class are returned by the [`fe.add_image()`](#feadd_image), [`fe.add_artwork()`](#feadd_artwork), [`fe.add_surface()`](#feadd_surface) and [`fe.add_clone()`](#feadd_clone) functions and also appear in the [`fe.obj`](#feobj) array (the Attract-Mode draw list). This class cannot be otherwise instantiated in a script.
+The class representing an image in Attract-Mode Plus. Instances of this class are returned by the [`fe.add_image()`](#feadd_image), [`fe.add_artwork()`](#feadd_artwork), [`fe.add_surface()`](#feadd_surface) and [`fe.add_clone()`](#feadd_clone) functions and also appear in the [`fe.obj`](#feobj) array (the Attract-Mode Plus draw list). This class cannot be otherwise instantiated in a script.
 
 **Properties**
 
@@ -1474,7 +1474,7 @@ The class representing an image in Attract-Mode. Instances of this class are ret
 -  `anchor_y` 🔶 - Get/set the y position of the midpoint for position and scale. Range is `[0.0...1.0]`. Default value is `0.0`, centre is `0.5`
 -  `rotation_origin_x` 🔶 - Get/set the x position of the midpoint for rotation. Range is `[0.0...1.0]`. Default value is `0.0`, centre is `0.5`
 -  `rotation_origin_y` 🔶 - Get/set the y position of the midpoint for rotation. Range is `[0.0...1.0]`. Default value is `0.0`, centre is `0.5`
--  `video_flags` - _[image & artwork only]_ Get/set video flags for this object. These flags allow you to override Attract-Mode's default video playback behaviour. Can be set to any combination of none or more of the following (i.e. `Vid.NoAudio | Vid.NoLoop`):
+-  `video_flags` - _[image & artwork only]_ Get/set video flags for this object. These flags allow you to override the default video playback behaviour. Can be set to any combination of none or more of the following (i.e. `Vid.NoAudio | Vid.NoLoop`):
    -  `Vid.Default`
    -  `Vid.ImagesOnly` (disable video playback, display images instead)
    -  `Vid.NoAudio` (silence the audio track)
@@ -1539,7 +1539,7 @@ The class representing an image in Attract-Mode. Instances of this class are ret
    img.subimg_height = img.texture_height * -1
    img.subimg_y = img.texture_height
    ```
--  Attract-Mode defers the loading of artwork and dynamic images (images with [_Magic Tokens_](#magic-tokens)) until after all layout and plug-in scripts have completed running. This means that the `texture_width`, `texture_height` and `file_name` attributes are not available when a layout or plug-in script first adds the image. These attributes become available during transitions such as `Transition.FromOldSelection` and `Transition.ToNewList`:
+-  Attract-Mode Plus defers the loading of artwork and dynamic images (images with [_Magic Tokens_](#magic-tokens)) until after all layout and plug-in scripts have completed running. This means that the `texture_width`, `texture_height` and `file_name` attributes are not available when a layout or plug-in script first adds the image. These attributes become available during transitions such as `Transition.FromOldSelection` and `Transition.ToNewList`:
 
    ```squirrel
    local art = fe.add_artwork( "snap" )
@@ -1561,7 +1561,7 @@ The class representing an image in Attract-Mode. Instances of this class are ret
 
 ### `fe.Text`
 
-The class representing a text label in Attract-Mode. Instances of this class are returned by the [`fe.add_text()`](#feadd_text) functions and also appear in the [`fe.obj`](#feobj) array (the Attract-Mode draw list). This class cannot be otherwise instantiated in a script.
+The class representing a text label in Attract-Mode Plus. Instances of this class are returned by the [`fe.add_text()`](#feadd_text) functions and also appear in the [`fe.obj`](#feobj) array (the Attract-Mode Plus draw list). This class cannot be otherwise instantiated in a script.
 
 **Properties**
 
@@ -1583,7 +1583,7 @@ The class representing a text label in Attract-Mode. Instances of this class are
 -  `bg_green` - Get/set green colour level for text background. Range is `[0...255]`. Default value is `0`.
 -  `bg_blue` - Get/set blue colour level for text background. Range is `[0...255]`. Default value is `0`.
 -  `bg_alpha` - Get/set alpha level for text background. Range is `[0...255]`. Default value is `0` (transparent).
--  `char_size` - Get/set the forced character size. If this is `<= 0` then Attract-Mode will auto-size based on `height`. Default value is `-1`.
+-  `char_size` - Get/set the forced character size. If this is `<= 0` then Attract-Mode Plus will auto-size based on `height`. Default value is `-1`.
 -  `glyph_size` - Get the height in pixels of the capital letter. Useful if you want to set the textbox height to match the letter height.
 -  `char_spacing` - Get/set the spacing factor between letters. Default value is `1.0`.
 -  `line_spacing` - Get/set the spacing factor between lines. Default value is `1.0` At values `0.75` or lower letters start to overlap. For uppercase texts it's around `0.5` It's advised to use this property with the new align modes.
@@ -1638,7 +1638,7 @@ The class representing a text label in Attract-Mode. Instances of this class are
 
 ### `fe.ListBox`
 
-The class representing the listbox in Attract-Mode. Instances of this class are returned by the [`fe.add_listbox()`](#feadd_listbox) functions and also appear in the [`fe.obj`](#feobj) array (the Attract-Mode draw list). This class cannot be otherwise instantiated in a script.
+The class representing the listbox in Attract-Mode Plus. Instances of this class are returned by the [`fe.add_listbox()`](#feadd_listbox) functions and also appear in the [`fe.obj`](#feobj) array (the Attract-Mode Plus draw list). This class cannot be otherwise instantiated in a script.
 
 **Properties**
 
@@ -1673,7 +1673,7 @@ The class representing the listbox in Attract-Mode. Instances of this class are 
    -  `ListAlign.Bottom` - Aligns options to the bottom.
    -  `ListAlign.Selection` - Aligns options to keep `sel_row` in-place during list change (with respect to `sel_margin` and `list_size`).
 -  `list_size` - Get the size of the list shown by the listbox. When the listbox is assigned as an overlay custom control this property will return the number of options available in the overlay dialog. This property is updated during `Transition.ShowOverlay`
--  `char_size` - Get/set the forced character size. If this is `<= 0` then Attract-Mode will auto-size based on the value of `height`/`rows`. Default value is `-1`.
+-  `char_size` - Get/set the forced character size. If this is `<= 0` then Attract-Mode Plus will auto-size based on the value of `height`/`rows`. Default value is `-1`.
 -  `glyph_size` - Get the height in pixels of the capital letter.
 -  `char_spacing` - Get/set the spacing factor between letters. Default value is `1.0`.
 -  `outline` 🔶 - Get/set the thickness of the outline applied to the text. Default value is `0.0`.
@@ -1736,7 +1736,7 @@ The class representing the listbox in Attract-Mode. Instances of this class are 
 
 ### `fe.Rectangle` 🔶
 
-The class representing a rectangle in Attract-Mode. Instances of this class are returned by the [`fe.add_rectangle()`](#feadd_rectangle-) function and also appear in the [`fe.obj`](#feobj) array (the Attract-Mode draw list). This class cannot be otherwise instantiated in a script.
+The class representing a rectangle in Attract-Mode Plus. Instances of this class are returned by the [`fe.add_rectangle()`](#feadd_rectangle-) function and also appear in the [`fe.obj`](#feobj) array (the Attract-Mode Plus draw list). This class cannot be otherwise instantiated in a script.
 
 **Properties**
 
@@ -1886,12 +1886,12 @@ The class representing a GLSL shader. Instances of this class are returned by th
 
 ## Constants
 
--  `FeVersion` - [string] The current Attract-Mode version.
--  `FeVersionNum` - [int] The current Attract-Mode version.
--  `FeConfigDirectory` - [string] The path to Attract-Mode's config directory.
+-  `FeVersion` - [string] The current Attract-Mode Plus version.
+-  `FeVersionNum` - [int] The current Attract-Mode Plus version.
+-  `FeConfigDirectory` - [string] The path to the config directory.
 -  `IntroActive` - [boolean] `true` if the intro is active, `false` otherwise.
 -  `Language` - [string] The configured language.
--  `OS` - [string] The Operating System that Attract-Mode is running under, will be one of: `"Windows"`, `"OSX"`, `"FreeBSD"`, `"Linux"`, or `"Unknown"`.
+-  `OS` - [string] The Operating System that Attract-Mode Plus is running under, will be one of: `"Windows"`, `"OSX"`, `"FreeBSD"`, `"Linux"`, or `"Unknown"`.
 -  `ScreenWidth` - [int] The screen width in pixels.
 -  `ScreenHeight` - [int] The screen height in pixels.
 -  `ScreenRefreshRate` - [int] The refresh rate of the main screen in Hz.

--- a/Makefile
+++ b/Makefile
@@ -34,16 +34,16 @@
 #
 # By default, if FontConfig gets enabled we link against the system's expat
 # library (because FontConfig uses expat too).  If FontConfig is not used
-# then Attract-Mode is statically linked to its own version of expat.
-# Uncomment next line to always link to Attract-Mode's version of expat.
+# then AM is statically linked to its own version of expat.
+# Uncomment next line to always link to AM's version of expat.
 #BUILD_EXPAT=1
 #
 # Uncomment next line for Windows static cross-compile build (mxe)
 #WINDOWS_STATIC=1
 #
-# By default, Attract-Mode on Windows is built as a GUI application, which
+# By default, AM on Windows is built as a GUI application, which
 # does not allow for command line interactions at the Windows console.
-# Uncomment the next line to build a console version of Attract-Mode
+# Uncomment the next line to build a console version of AM
 # instead (Windows only)
 #WINDOWS_CONSOLE=1
 #

--- a/Readme.md
+++ b/Readme.md
@@ -27,29 +27,29 @@
 
 ## Overview
 
-Attract-Mode is a graphical frontend for command line emulators such as `MAME`, `MESS`, and `Nestopia`. It hides the underlying operating system and is intended to be controlled with a joystick, gamepad or spin dial, making it ideal for use in arcade cabinet setups.
+Attract-Mode Plus is a graphical frontend for command line emulators such as `MAME`, `MESS`, and `Nestopia`. It hides the underlying operating system and is intended to be controlled with a joystick, gamepad or spin dial, making it ideal for use in arcade cabinet setups.
 
-Attract-Mode was originally developed for Linux. It is known to work on Linux (x86, x86-64, ARM, Raspberry Pi), Mac OS X and Windows based-systems.
+Attract-Mode Plus was originally developed for Linux. It is known to work on Linux (x86, x86-64, ARM, Raspberry Pi), Mac OS X and Windows based-systems.
 
-Attract-Mode is licensed under the terms of the GNU General Public License, version 3 or later.
+Attract-Mode Plus is licensed under the terms of the GNU General Public License, version 3 or later.
 
 Visit <http://attractmode.org> for more information.
 
-See [Compile.md](./Compile.md) if you intend to compile Attract-Mode from source.
+See [Compile.md](./Compile.md) if you intend to compile Attract-Mode Plus from source.
 
 ---
 
 ## Quick Start
 
-1. Run Attract-Mode. By default, Attract-Mode will look for its configuration files in the `$HOME/.attract` directory on Linux and Mac OS X, and in the current working directory on Windows. If you want to use a different location for the Attract-Mode configuration then you need to specify it at the command line as follows:
+1. Run Attract-Mode Plus. By default it will look for its configuration files in the `$HOME/.attract` directory on Linux and Mac OS X, and in the current working directory on Windows. If you want to use a different location for the Attract-Mode Plus configuration then you need to specify it at the command line as follows:
    ```sh
    attract --config /my/config/location
    ```
-2. If you are running Attract-Mode for the first time, you will be prompted to select the language to use and then the frontend will load directly to its configuration mode. If you do not start in config mode, pressing the `TAB` key will get you there. By default, config mode can be navigated using the up/ down arrows, enter to select an option, and escape to go back.
+2. If you are running Attract-Mode Plus for the first time, you will be prompted to select the language to use and then the frontend will load directly to its configuration mode. If you do not start in config mode, pressing the `TAB` key will get you there. By default, config mode can be navigated using the up/ down arrows, enter to select an option, and escape to go back.
 
-3. Select the `Emulators` option, where you will be presented with the option of editing the configuration for the emulators Attract-Mode auto-detected (if any). `Edit` an existing emulator or select `Add` to add a new emulator configuration. Default configuration templates are provided for various popular emulators to help you get started, however some settings will likely have to be customized for your system (file locations etc).
+3. Select the `Emulators` option, where you will be presented with the option of editing the configuration for the emulators Attract-Mode Plus auto-detected (if any). `Edit` an existing emulator or select `Add` to add a new emulator configuration. Default configuration templates are provided for various popular emulators to help you get started, however some settings will likely have to be customized for your system (file locations etc).
 
-4. Once you have an emulator configured correctly for your system, select the `Generate Collection/Rom List` option from the emulator's configuration menu. Attract-Mode will use the configured emulator settings to generate a list of available games for the emulator. Next select the `Scrape Artwork` option if you want to have Attract-Mode go and automatically download artwork images for the emulator from the web.
+4. Once you have an emulator configured correctly for your system, select the `Generate Collection/Rom List` option from the emulator's configuration menu. Attract-Mode Plus will use the configured emulator settings to generate a list of available games for the emulator. Next select the `Scrape Artwork` option if you want to have Attract-Mode Plus go and automatically download artwork images for the emulator from the web.
 
 5. Exit config mode by selecting the `Back` option a few times. You should now have a usable front-end!
 
@@ -57,11 +57,11 @@ See [Compile.md](./Compile.md) if you intend to compile Attract-Mode from source
 
 ## Basic Organization
 
-At its most basic level, Attract-Mode is organized into `Displays`, of which you can configure one or more. Each `Display` is a grouping of the following:
+At its most basic level, Attract-Mode Plus is organized into `Displays`, of which you can configure one or more. Each `Display` is a grouping of the following:
 
 **Collection / Rom List**
 
--  A Collection/Rom List is the listing of available games/roms to show. Romlists are text files located in the `romlists` directory. They are created by Attract-Mode using the `Generate Collection/Rom List` option available when configuring an emulator, or by using the `--build-romlist` or `--import-romlist` command line options.
+-  A Collection/Rom List is the listing of available games/roms to show. Romlists are text files located in the `romlists` directory. They are created by Attract-Mode Plus using the `Generate Collection/Rom List` option available when configuring an emulator, or by using the `--build-romlist` or `--import-romlist` command line options.
 
 **Layout**
 
@@ -81,7 +81,7 @@ At its most basic level, Attract-Mode is organized into `Displays`, of which you
 
 ### Controls
 
-The inputs used to control Attract-Mode can be configured from from the `Controls` menu in config mode. Attract-Mode actions can be mapped to most keyboard, mouse and joystick inputs, including combinations. Here is a list of the default control mappings:
+The inputs used to control Attract-Mode Plus can be configured from from the `Controls` menu in config mode. Attract-Mode Plus actions can be mapped to most keyboard, mouse and joystick inputs, including combinations. Here is a list of the default control mappings:
 
 | Keyboard          | Joystick          | Action                  |
 | ----------------- | ----------------- | ----------------------- |
@@ -111,7 +111,7 @@ For example, you might want to have a filter that only shows 1980's multiplayer 
 
 Filters use regular expressions, which allow for powerful text matching capabilities. From the example above, the `198.` will match any four letter word that starts with `198`, with the `.` matching _any_ character thereafter.
 
-Filters are stored in `attract.cfg` and may be edited directly. Keep in mind that changes to this file are only loaded when AM first starts, and the file is overwritten when AM exits. Rules are in the format `target comparison value`.
+Filters are stored in `attract.cfg` and may be edited directly. Keep in mind that changes to this file are only loaded when AM+ first starts, and the file is overwritten when AM+ exits. Rules are in the format `target comparison value`.
 
 -  `target` - Can be one of the Rule Targets listed below.
 -  `comparison` - Can be one of the following:
@@ -130,20 +130,20 @@ Filters are stored in `attract.cfg` and may be edited directly. Keep in mind tha
 
 ### Sound
 
-To configure sounds, place the sound file in the `sounds` subdirectory of your Attract-Mode config directory. The sound file can then be selected from the `Sound` menu when in config mode and mapped to an action or event. Attract-Mode should support any sound format supported by FFmpeg (`MP3`, etc).
+To configure sounds, place the sound file in the `sounds` subdirectory of your Attract-Mode Plus config directory. The sound file can then be selected from the `Sound` menu when in config mode and mapped to an action or event. Attract-Mode Plus should support any sound format supported by FFmpeg (`MP3`, etc).
 
 ### Artwork
 
-Attract-Mode supports `PNG`, `JPEG`, `GIF`, `BMP` and `TGA` image formats. For video formats, Attract-Mode should support any video format supported by FFmpeg (`MP4`, `FLV`, `AVI`, etc). When deciding what file to use for a particular artwork type, Attract-Mode will use the artwork selection order set out below.
+Attract-Mode Plus supports `PNG`, `JPEG`, `GIF`, `BMP` and `TGA` image formats. For video formats, Attract-Mode Plus should support any video format supported by FFmpeg (`MP4`, `FLV`, `AVI`, etc). When deciding what file to use for a particular artwork type, Attract-Mode Plus will use the artwork selection order set out below.
 
-The location of artwork resources is configured on a per-emulator basis in the `Emulators` configuration menu. Attract-Mode's default artworks are:
+The location of artwork resources is configured on a per-emulator basis in the `Emulators` configuration menu. Default artworks are:
 
 -  `"marquee"` - For cabinet marquee images.
--  `"snap"` - For attract-mode videos and game screen shots.
+-  `"snap"` - For videos and game screen shots.
 -  `"flyer"` - For game flyer/box art.
 -  `"wheel"` - For Hyperspin wheel art.
 
-You can add others as needed in the `Emulators` configuration menu. Multiple paths can be specified for each artwork, in which case Attract-Mode will check each path in the order they are specified before moving to the next check in the selection order.
+You can add others as needed in the `Emulators` configuration menu. Multiple paths can be specified for each artwork, in which case Attract-Mode Plus will check each path in the order they are specified before moving to the next check in the selection order.
 
 **Artwork Selection Order**
 
@@ -161,39 +161,39 @@ You can add others as needed in the `Emulators` configuration menu. Multiple pat
    -  `[ArtLabel].\*` - Image, i.e. "marquee.png"
 -  When looking for artwork for the `Displays Menu`, artwork is loaded from the `menu-art` subdirectory.
    -  Artwork matching the Display's name or the Display's romlist name are matched from the corresponding artwork directories located there.
--  If no file match is found, Attract-Mode will check for a subdirectory that meets the match criteria.
-   -  If a subdirectory is found (for example a `pacman` directory in the configured artwork path) then Attract-Mode will then pick a random video or image from that directory.
+-  If no file match is found, Attract-Mode Plus will check for a subdirectory that meets the match criteria.
+   -  If a subdirectory is found (for example a `pacman` directory in the configured artwork path) then Attract-Mode Plus will then pick a random video or image from that directory.
 -  If no files are found matching the above rules, then the artwork is not drawn.
 
 ### Layouts
 
-Attract-Mode's layouts are located in the `layouts` directory. Each layout has to be in its own subdirectory or contained in a `.zip` file. Attract-Mode's native layouts are made up of a squirrel script (a `.nut` file) and related resources. See [Layouts.md](./Layouts.md) for more information on Attract-Mode layouts.
+Attract-Mode Plus layouts are located in the `layouts` directory. Each layout has to be in its own subdirectory or contained in a `.zip` file. Native layouts are made up of a squirrel script (a `.nut` file) and related resources. See [Layouts.md](./Layouts.md) for more information on Attract-Mode Plus layouts.
 
-Attract-Mode can also display layouts made for other frontends, including `MaLa` and `Hyperspin`. This feature is experimental, and certain features from these other frontends might not be fully implemented.
+Attract-Mode Plus can also display layouts made for other frontends, including `MaLa` and `Hyperspin`. This feature is experimental, and certain features from these other frontends might not be fully implemented.
 
--  `MaLa` - Copy the layout and related resources into a new subdirectory of the `layouts` directory, or place a `zip`, `7z` or `rar` file containing these things into the `layouts` directory. After doing this, you hould be able to select the layout when configuring a Display in Attract-Mode, just as you would for a native Attract-Mode layout.
--  `Hyperspin` - Copy the Hyperspin `Media` directory into its own directory in the Attract-Mode layouts directory. Create a Display in Attract-Mode and configure the layout to be the directory you copied `Media` into. The Display's name needs to match the name of one of the system subdirectories in the Hyperspin `Media` directory. This will allow Attract-Mode to find the Hyperspin themes and graphics to use. So for example, naming the Display `MAME` will cause it to match Hyperspin's `MAME/Themes/_` for themes, `MAME/Images/Artwork1/_` for artwork1, etc. Note that the wheel images are located using Attract-Mode's built-in wheel artwork. Wheel images located in the Hyperspin directories are ignored.
+-  `MaLa` - Copy the layout and related resources into a new subdirectory of the `layouts` directory, or place a `zip`, `7z` or `rar` file containing these things into the `layouts` directory. After doing this, you hould be able to select the layout when configuring a Display in Attract-Mode Plus, just as you would for a native layout.
+-  `Hyperspin` - Copy the Hyperspin `Media` directory into its own directory in the Attract-Mode Plus layouts directory. Create a Display in Attract-Mode Plus and configure the layout to be the directory you copied `Media` into. The Display's name needs to match the name of one of the system subdirectories in the Hyperspin `Media` directory. This will allow Attract-Mode Plus to find the Hyperspin themes and graphics to use. So for example, naming the Display `MAME` will cause it to match Hyperspin's `MAME/Themes/_` for themes, `MAME/Images/Artwork1/_` for artwork1, etc. Note that the wheel images are located using the built-in wheel artwork. Wheel images located in the Hyperspin directories are ignored.
 
 ### Plug-ins
 
-Plug-ins are squirrel scripts that need to be placed in the `plugins` subdirectory of your Attract-Mode config directory. Available plugins can be enabled/disabled and configured from the `Plug-Ins` menu when in config mode. See [Layouts.md](./Layouts.md) for a description of Attract-Mode's Plug-in API.
+Plug-ins are squirrel scripts that need to be placed in the `plugins` subdirectory of your Attract-Mode Plus config directory. Available plugins can be enabled/disabled and configured from the `Plug-Ins` menu when in config mode. See [Layouts.md](./Layouts.md) for a description of Attract-Mode Plus Plug-in API.
 
 ### Romlists
 
-Collection/Rom lists are saved in the `romlist` subdirectory of your Attract-Mode config directory. Each list is a semi-colon delimited text file that can be edited by most common spreadsheet programs (be sure to load it as `Text CSV`). The file has one game entry per line, with the very first line of the file specifying what each column represents.
+Collection/Rom lists are saved in the `romlist` subdirectory of your Attract-Mode Plus config directory. Each list is a semi-colon delimited text file that can be edited by most common spreadsheet programs (be sure to load it as `Text CSV`). The file has one game entry per line, with the very first line of the file specifying what each column represents.
 
 ---
 
 ## Romlist Generation
 
-In addition to the romlist generation function available in config mode, Attract-Mode can generate a single romlist containing roms from multiple emulators using the command line.
+In addition to the romlist generation function available in config mode, Attract-Mode Plus can generate a single romlist containing roms from multiple emulators using the command line.
 
 ```sh
 attract --build-romlist <emu>...
 ```
 
 You can also import romlists from other frontends. Supported files include:
-- `*.txt` - Attract-Mode lists
+- `*.txt` - Attract-Mode Plus lists
 - `*.xml` - Mame listxml, listsoftware, and HyperSpin lists
 - `*.lst` - MameWah, Wah!Cade
 
@@ -201,7 +201,7 @@ You can also import romlists from other frontends. Supported files include:
 attract --import-romlist <file> [emu]
 ```
 
-The `--build-romlist` and `--import-romlist` options can be chained together to generate combined Attract-Mode romlists. The following example combines the entries from `mame.lst` and `nintendo.lst` (located in the current directory) into a single Attract-Mode romlist. The `mame` emulator will be used for the `mame.lst` games, while the `nestopia` emulator will be used for the `nintendo.lst` games.
+The `--build-romlist` and `--import-romlist` options can be chained together to generate combined Attract-Mode Plus romlists. The following example combines the entries from `mame.lst` and `nintendo.lst` (located in the current directory) into a single Attract-Mode Plus romlist. The `mame` emulator will be used for the `mame.lst` games, while the `nestopia` emulator will be used for the `nintendo.lst` games.
 
 ```sh
 attract --import-romlist mame.lst --import-romlist nintendo.lst nestopia
@@ -213,7 +213,7 @@ Filter rules can be applied when importing or building a romlist using the `--fi
 attract --build-romlist mame --filter "Year equals 198."
 ```
 
-If you wish to specify the name of the created romlist at the command line, you can do so with the `--output <name>` option. Beware that this will overwrite any existing Attract-Mode romlist with the specified name.
+If you wish to specify the name of the created romlist at the command line, you can do so with the `--output <name>` option. Beware that this will overwrite any existing Attract-Mode Plus romlist with the specified name.
 
 ---
 
@@ -225,7 +225,7 @@ A complete list of command line options can be found by running:
 attract --help
 ```
 
-Attract-Mode by default will print log messages to the console window (stdout). To suppress these messages, run with the following option:
+Attract-Mode Plus by default will print log messages to the console window (stdout). To suppress these messages, run with the following option:
 
 ```sh
 attract --loglevel silent

--- a/config/default-emulator.cfg
+++ b/config/default-emulator.cfg
@@ -1,4 +1,4 @@
-# Attract-Mode: Default emulator settings
+# Attract-Mode Plus: Default emulator settings
 #
 args                 "[romfilename]"
 rompath              $HOME/[emulator]/roms/

--- a/config/default-filter.cfg
+++ b/config/default-filter.cfg
@@ -1,3 +1,3 @@
-# Attract-Mode: Default filter settings
+# Attract-Mode Plus: Default filter settings
 #
 #rule                 Title not_contains bootleg|prototype|Trivia|Quiz|Mahjong

--- a/debian/control
+++ b/debian/control
@@ -17,9 +17,9 @@ Homepage: http://attractmode.org
 Package: attractplus
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: Attract-Mode emulator frontend
- Attract-Mode is a graphical frontend for command line emulators such as MAME,
+Description: Attract-Mode Plus emulator frontend
+ Attract-Mode Plus is a graphical frontend for command line emulators such as MAME,
  MESS and Nestopia. It hides the underlying operating system and is intended
  to be controlled with a joystick, gamepad or spin dial, making it ideal for
- use in arcade cabinets. Attract-Mode is open source and runs on Linux, OS X
+ use in arcade cabinets. Attract-Mode Plus is open source and runs on Linux, OS X
  and Windows.

--- a/extlibs/squirrel/sqstdlib/sqstdio.cpp
+++ b/extlibs/squirrel/sqstdlib/sqstdio.cpp
@@ -5,11 +5,11 @@
 #include <sqstdio.h>
 #include "sqstdstream.h"
 
-// Begin Attract-Mode specific change
+// Begin AM specific change
 #ifdef _WIN32
 #include <SFML/System/Utf.hpp>
 #endif
-// End Attract-Mode specific change
+// End AM specific change
 
 #define SQSTD_FILE_TYPE_TAG (SQSTD_STREAM_TYPE_TAG | 0x00000001)
 //basic API
@@ -17,7 +17,7 @@ SQFILE sqstd_fopen(const SQChar *filename ,const SQChar *mode)
 {
 #ifndef SQUNICODE
 
-// Begin Attract-Mode specific change
+// Begin AM specific change
 #ifdef _WIN32
 	std::string fn = filename;
 	std::string m = mode;
@@ -31,7 +31,7 @@ SQFILE sqstd_fopen(const SQChar *filename ,const SQChar *mode)
 #else
 	return (SQFILE)fopen(filename,mode);
 #endif
-// End Attract-Mode specific change
+// End AM specific change
 
 #else
 	return (SQFILE)_wfopen(filename,mode);

--- a/resources/language/cn.msg
+++ b/resources/language/cn.msg
@@ -57,8 +57,8 @@ Emulators;模拟器
 Enable Multiple Monitors;使多个显示器
 Enabled;显示
 Exception;其他 Exception
-Exit Attract-Mode;退出ATTRACT-MODE
-Exit Attract-Mode?;退出ATTRACT-MODE吗?
+Exit Attract-Mode Plus;退出Attract-Mode Plus
+Exit Attract-Mode Plus?;退出Attract-Mode Plus吗?
 Exit Command;退出指令
 #Exit Message;
 Filter Name;分类名称
@@ -270,7 +270,7 @@ Scraping Artwork: $1%;正在搜刮 $1% 插图
 
 # -- confirm_dialog --
 Add '$1' to Favourites?;添加 '$1' 到收藏？
-#Attract-Mode detected emulator(s) that can be imported automatically.  Import them now?;
+#Attract-Mode Plus detected emulator(s) that can be imported automatically.  Import them now?;
 #Auto-detect emulators?;
 #Clear Hotkey?;
 Delete display '$1'?;删除 '$1' 界面?
@@ -426,7 +426,7 @@ Exit Hotkey;退出热键
 #_help_emu_add;
 #_help_emu_args;
 #_help_emu_delete;
-_help_emu_executable;The full path and name of the emulator executable. Possible variables: $HOME = User's home dir, $PROGDIR = Attract-Mode program dir. Windows OS additionally has %SYSTEMROOT% and %PROGRAMFILES% matching system environment variables.
+_help_emu_executable;The full path and name of the emulator executable. Possible variables: $HOME = User's home dir, $PROGDIR = Attract-Mode Plus program dir. Windows OS additionally has %SYSTEMROOT% and %PROGRAMFILES% matching system environment variables.
 #_help_emu_exit_hotkey;
 #_help_emu_gen_romlist;
 #_help_emu_import_extras;
@@ -477,7 +477,7 @@ _help_input_action;
 #_help_misc_anisotropic_filtering;
 #_help_misc_antialiasing;
 #_help_misc_check_for_updates;
-_help_misc_confirm_exit;Confirm before exiting Attract-Mode?
+_help_misc_confirm_exit;Confirm before exiting Attract-Mode Plus?
 _help_misc_confirm_favs;Confirm the addition/removal of Favourites?
 #_help_misc_exit_command;
 #_help_misc_exit_message;

--- a/resources/language/de.msg
+++ b/resources/language/de.msg
@@ -57,8 +57,8 @@ Emulators;Emulatoren
 Enable Multiple Monitors;mehrere Monitore zulassen
 Enabled;Aktiviert
 Exception;Ausnahme
-Exit Attract-Mode;Attract-Mode beenden
-Exit Attract-Mode?;Attract-Mode beenden?
+Exit Attract-Mode Plus;Attract-Mode Plus beenden
+Exit Attract-Mode Plus?;Attract-Mode Plus beenden?
 Exit Command;Kommando zum Beenden
 Exit Message;Abschiedsnachricht
 Filter Name;Bezeichnung des Filters
@@ -270,7 +270,7 @@ Scraping Artwork: $1%;Scrape Bilddatei: $1%
 
 # -- confirm_dialog --
 Add '$1' to Favourites?;Soll '$1' zu Favoriten hinzugefügt werden?
-Attract-Mode detected emulator(s) that can be imported automatically.  Import them now?;Attract-Mode hat Emulatoren gefunden, die automatisch hinzugefügt werden können, sollen diese jetzt integriert werden?
+Attract-Mode Plus detected emulator(s) that can be imported automatically.  Import them now?;Attract-Mode Plus hat Emulatoren gefunden, die automatisch hinzugefügt werden können, sollen diese jetzt integriert werden?
 #Auto-detect emulators?;
 Clear Hotkey?;Tastenkombination entfernen?
 Delete display '$1'?;Bildschirm '$1' löschen?
@@ -427,13 +427,13 @@ _help_emu_add;Neuen Emulator hinzufügen
 _help_emu_args;Die Kommandozeilenargumente für diesen Emulator. Folgende Einträge werden entsprechend ersetzt: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn]
 _help_emu_delete;Lösche den Eintrag für diesen Emulator
 _help_emu_executable;Der komplette Pfad und die Bezeichnung der Programmdatei des Emulators. $HOME wird durch die Homedir des Users ersetzt
-_help_emu_exit_hotkey;Definiere einen globalen Hotkey, um den Emulator zu verlassen.  Attract-Mode wird den Emulator Prozess beenden, wenn dieser Hotkey betätigt wird.
+_help_emu_exit_hotkey;Definiere einen globalen Hotkey, um den Emulator zu verlassen.  Attract-Mode Plus wird den Emulator Prozess beenden, wenn dieser Hotkey betätigt wird.
 _help_emu_gen_romlist;Generiere eine Romliste, indem der eingestellte ROM-Pfad nach ROMs mit der definierten Endung durchsucht wird. Falls verfügbar, werden XML-Informationen und zusätzliche Import-Dateien mit einbezogen.
 _help_emu_import_extras;Pfad zu beliebigen zusätzlichen Dateien welche gelesen werden müssen wenn eine Romliste für diesen Emulator generiert wird. Unterstützte Dateien sind: catver.ini (für Spiele Kategorien) und nplayers.ini (für Anzahl an Spielern).  Mehrere Dateipfade können durch Semikolon getrennt werden.
 _help_emu_info_source;Verwende "listxml" falls der Emulator mame -listxml Ausgabe bereitstellt, "listsoftware" für mame/mess -listsoftware Ausgabe, "thegamesdb.net" um Daten von thegamesdb.net zu scrapen, oder "steam" um von einer Steam-Installation zu lesen. "listsoftware" und "thegamesdb.net" benötigen zusätzlich die Konfiguration einer System-Kennung welche von diesen Ressourcen erkannt wird
 #_help_emu_name;
-_help_emu_nb_mode_wait;Definiere eine minimale Wartezeit (in Sekunden).  Attract-Mode wird bei Aktivierung dieses Emulators warten bis die minimale Zeit verstrichen ist und es zum Vordergund-Fenster wird. Dies wird speziell benötigt, um Steam korrekt unter Windows auszuführen. Lass es auf 0 stehen, außer du weißt, dass du es benötigst
-_help_emu_pause_hotkey;Definiere eine globale Tastenkombination um Emulatoren zu pausieren. Wird diese benutzt pausiert Attract-Mode jegliche Emulation und kehrt zum Frontend zurück. Um die Emulation fortzusetzen muss dasselbe Spiel wie vorher ausgewählt werden.
+_help_emu_nb_mode_wait;Definiere eine minimale Wartezeit (in Sekunden).  Attract-Mode Plus wird bei Aktivierung dieses Emulators warten bis die minimale Zeit verstrichen ist und es zum Vordergund-Fenster wird. Dies wird speziell benötigt, um Steam korrekt unter Windows auszuführen. Lass es auf 0 stehen, außer du weißt, dass du es benötigst
+_help_emu_pause_hotkey;Definiere eine globale Tastenkombination um Emulatoren zu pausieren. Wird diese benutzt pausiert Attract-Mode Plus jegliche Emulation und kehrt zum Frontend zurück. Um die Emulation fortzusetzen muss dasselbe Spiel wie vorher ausgewählt werden.
 _help_emu_romext;Die ROM Dateiendung(en) für diesen Emulator (z.B. .zip). Mehrere Endungen können durch Semikolon getrennt werden. Gib "<DIR>" als Eintrag an, falls die Spiele in separaten Unterverzeichnissen gespeichert sind
 _help_emu_rompath;Der Pfad zu den ROMs für diesen Emulator. Mehrere Pfade können durch Semikolon getrennt werden.
 _help_emu_scrape_artwork;Scrape fehlende Bilddateien für diesen Emulator von TheGamesDB.net und mamedb.com
@@ -464,8 +464,8 @@ _help_input_default_action;Setze ein Standardverhalten für diese Eingabe
 _help_input_delete;Dieses Steuerungs-Mapping löschen
 _help_layout_file;Manche Themen haben mehrere .NUT Dateien. Wähle welche standardgemäß verwendet werden soll
 #_help_layout_name;
-_help_main_control;Konfiguriere die Joystick-, Tastatur- und Maus-Eingaben die Attract-Mode steuern
-_help_main_display;Konfiguriere die Romlisten/Themen-Gruppierungen (die "Bildschirme") welche in Attract-Mode zum Durchblättern verfügbar sind
+_help_main_control;Konfiguriere die Joystick-, Tastatur- und Maus-Eingaben die Attract-Mode Plus steuern
+_help_main_display;Konfiguriere die Romlisten/Themen-Gruppierungen (die "Bildschirme") welche in Attract-Mode Plus zum Durchblättern verfügbar sind
 _help_main_emu;Konfiguriere verfügbare Spielsysteme und Emulatoren
 _help_main_intro;Intro konfigurieren
 _help_main_misc;Konfiguriere sonstige Einstellungen
@@ -477,7 +477,7 @@ _help_main_sound;Konfiguriere Klang-Lautstärke, Klang->Ereignis Zuordnungen und
 #_help_misc_anisotropic_filtering;
 #_help_misc_antialiasing;
 #_help_misc_check_for_updates;
-_help_misc_confirm_exit;Bestätigung vor Verlassen von Attract-Mode verlangen?
+_help_misc_confirm_exit;Bestätigung vor Verlassen von Attract-Mode Plus verlangen?
 _help_misc_confirm_favs;Das Hinzufügen/Löschen zu den Favoriten bestätigen
 _help_misc_exit_command;Befehl der ausgeführt wird, wenn Beenden (Bestätigen) gewählt wird [z.B. "sudo shutdown"]
 _help_misc_exit_message;Alternative Abschiedsnachricht beim Beenden des Programms [z.B. "Erstmal"]
@@ -486,17 +486,17 @@ _help_misc_group_clones;Gruppieren Sie alle Klone eines Spiels unter einem einzi
 _help_misc_hide_brackets;Verberge bei der Anzeige der Spieletitel den Text in Klammern
 _help_misc_hide_console;Verstecke das Kommandozeilenfenster beim Starten. Bitte beachte, dass dies nur in einer Windows Schaltfläche funktioniert. Wird die Anwendung durch ein Kommandozeilenfenster, wie z.B. einer Batch-Datei, gestartet, wird der Ladevorgang and dieses Fenster gebunden sein
 #_help_misc_image_cache_mbytes;
-_help_misc_language;Wähle die Sprache in der Attract-Mode angezeigt wird
+_help_misc_language;Wähle die Sprache in der Attract-Mode Plus angezeigt wird
 _help_misc_layout_preview;Zeigen Sie Änderungen an der Layoutkonfiguration sofort an
-_help_misc_multiple_monitors;Wähle ob Attract-Mode mehrere Monitore verwendet. Ist "No" gewählt, kann das Flackern beim Start einiger Spiele reduzieren
+_help_misc_multiple_monitors;Wähle ob Attract-Mode Plus mehrere Monitore verwendet. Ist "No" gewählt, kann das Flackern beim Start einiger Spiele reduzieren
 #_help_misc_power_saving;
 _help_misc_quick_menu;Legt fest, ob Menüs mit derselben Taste geöffnet und geschlossen werden können. Ermöglicht außerdem das Wechseln zwischen Menüs, ohne diese vorher schließen zu müssen
 #_help_misc_screen_rotation;
-_help_misc_startup_mode;Wähle, was passieren soll, wenn Attract-Mode das erste Mal startet
-_help_misc_track_usage;Konfiguriere, ob Attract-Mode die Nutzung protokollieren soll (Gesamtspielzeit und Anzahl der Spielestarts pro Spiel)
-_help_misc_ui_color;Wählen Sie die Farbe aus, die in der Benutzeroberfläche von Attract-Mode verwendet werden soll
+_help_misc_startup_mode;Wähle, was passieren soll, wenn Attract-Mode Plus das erste Mal startet
+_help_misc_track_usage;Konfiguriere, ob Attract-Mode Plus die Nutzung protokollieren soll (Gesamtspielzeit und Anzahl der Spielestarts pro Spiel)
+_help_misc_ui_color;Wählen Sie die Farbe aus, die in der Benutzeroberfläche von Attract-Mode Plus verwendet werden soll
 _help_misc_video_decoder;Konfiguriere den Decoder für die Video Wiedergabe (falls mehrere Decoder verfügbar sind)
-_help_misc_window_mode;Lege fest, ob Attract-Mode in einem Fenster läuft oder den Bildschirm füllt
+_help_misc_window_mode;Lege fest, ob Attract-Mode Plus in einem Fenster läuft oder den Bildschirm füllt
 _help_plugin_command;Die ausführbare Datei, welche mit diesem Plug-in verknüpft ist
 _help_plugin_enabled;Festlegen, ob dieses Plug-in aktiviert ist
 #_help_plugin_name;

--- a/resources/language/en.msg
+++ b/resources/language/en.msg
@@ -58,8 +58,8 @@ Emulators;Emulators
 Enable Multiple Monitors;Enable Multiple Monitors
 Enabled;Enabled
 Exception;Exception
-Exit Attract-Mode;Exit Attract-Mode
-Exit Attract-Mode?;Exit Attract-Mode?
+Exit Attract-Mode Plus;Exit Attract-Mode Plus
+Exit Attract-Mode Plus?;Exit Attract-Mode Plus?
 Exit Command;Exit Command
 Exit Message;Exit Message
 Filter Name;Filter Name
@@ -272,7 +272,7 @@ Scraping Artwork: $1%;Scraping Artwork: $1%
 
 # -- confirm_dialog --
 Add '$1' to Favourites?;Add '$1' to Favourites?
-Attract-Mode detected emulator(s) that can be imported automatically.  Import them now?;Attract-Mode detected emulator(s) that can be imported automatically.  Import them now?
+Attract-Mode Plus detected emulator(s) that can be imported automatically.  Import them now?;Attract-Mode Plus detected emulator(s) that can be imported automatically.  Import them now?
 Auto-detect emulators?;Auto-detect emulators?
 Clear Hotkey?;Clear Hotkey?
 Delete display '$1'?;Delete display '$1'?
@@ -429,14 +429,14 @@ _help_displaysmenu;Configure options for the Displays Menu
 _help_emu_add;Add a new emulator
 _help_emu_args;The command line arguments for this emulator.  The following get substituted appropriately: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn], [workdir], [nothing], as well as any valid magic tokens (see layout documentation)
 _help_emu_delete;Delete the entry for this emulator
-_help_emu_executable;The full path and name of the emulator executable. Possible variables: $HOME = User's home dir, $PROGDIR = Attract-Mode program dir. Windows OS additionally have %SYSTEMROOT% and %PROGRAMFILES% matching system environment variables.
-_help_emu_exit_hotkey;Set a global hotkey to exit the emulator.  Attract-Mode will terminate the emulator process if this hotkey gets pressed
+_help_emu_executable;The full path and name of the emulator executable. Possible variables: $HOME = User's home dir, $PROGDIR = Attract-Mode Plus program dir. Windows OS additionally have %SYSTEMROOT% and %PROGRAMFILES% matching system environment variables.
+_help_emu_exit_hotkey;Set a global hotkey to exit the emulator.  Attract-Mode Plus will terminate the emulator process if this hotkey gets pressed
 _help_emu_gen_romlist;Generate a romlist by searching the configured rom path for roms with the configured extension, incorporating XML and additional import file information into the generated list (if available)
 _help_emu_import_extras;Path to any additional files that need to be read when generating a romlist for this emulator.  Supported files are: catver.ini (categories), nplayers.ini (number of players), series.ini (series), language.ini (language) and mame.xml.  Multiple file paths can be entered if separated by a semicolon
 _help_emu_info_source;Use "listxml" for mame -listxml output, "listsoftware" for mame/mess -listsoftware output, "thegamesdb.net" to scrape data from thegamesdb.net, "steam" to read from a steam installation, or "scummvm" if the emulator is scummvm.  "listsoftware" and "thegamesdb.net" also require that a System Identifier recognized by those sources be configured
 _help_emu_name;Edit Emulator
 _help_emu_nb_mode_wait;If this is non-zero, the emulator will be run in non-blocking mode.  The frontend will wait up to this number of seconds to lose focus to the emulator's window, and will wake up again when focus returns to the frontend's window.  This is necessary for launching programs like Steam correctly.  Should be 0 unless you know you need it
-_help_emu_pause_hotkey;Set a global hotkey to pause the emulator.  When pressed, Attract-Mode will pause the emulator process and return to the frontend. The emulator process can be resumed by selecting the same game again in the frontend.
+_help_emu_pause_hotkey;Set a global hotkey to pause the emulator.  When pressed, Attract-Mode Plus will pause the emulator process and return to the frontend. The emulator process can be resumed by selecting the same game again in the frontend.
 _help_emu_romext;The rom extension(s) for this emulator (i.e. .zip).  Multiple extensions can be entered if separated by a semicolon.  Specify "<DIR>" as an entry if games are stored in separate subdirectories
 _help_emu_rompath;The path to the roms for this emulator.  Multiple paths can be entered if separated by a semicolon.
 _help_emu_scrape_artwork;Scrape missing artwork images for this emulator from the net
@@ -467,8 +467,8 @@ _help_input_default_action;Set the default behaviour for this control
 _help_input_delete;Remove this input mapping
 _help_layout_file;Some layouts provide multiple layout*.nut files.  Select which layout file to use
 _help_layout_name;Configure Layout
-_help_main_control;Configure the joystick, keyboard and mouse inputs that control Attract-Mode
-_help_main_display;Configure the romlist/layout groupings (a.k.a. "Displays") that are available to be cycled through in Attract-Mode
+_help_main_control;Configure the joystick, keyboard and mouse inputs that control Attract-Mode Plus
+_help_main_display;Configure the romlist/layout groupings (a.k.a. "Displays") that are available to be cycled through in Attract-Mode Plus
 _help_main_emu;Configure emulator settings
 _help_main_intro;Configure intro
 _help_main_misc;Configure general settings
@@ -480,7 +480,7 @@ _help_main_sound;Configure sound volumes, sound event mappings and the ambient s
 _help_misc_anisotropic_filtering;Set the anisotropic filtering level for textures. This will improve the quality of scaled textures
 _help_misc_antialiasing;Set the anti-aliasing level
 _help_misc_check_for_updates;Configure whether Attract-Mode Plus should check for available updates on startup and display an update notification dialog when a new version is found.
-_help_misc_confirm_exit;Confirm the exiting of Attract-Mode
+_help_misc_confirm_exit;Confirm the exiting of Attract-Mode Plus
 _help_misc_confirm_favs;Confirm the addition/removal of Favourites
 _help_misc_exit_command;Command to execute when exiting the frontend [i.e. "sudo shutdown"]
 _help_misc_exit_message;Alternate message to exit the frontend [i.e. "Shut Down System"]
@@ -488,19 +488,19 @@ _help_misc_filter_wrap_mode;Set what happens when the "Next Filter" or "Previous
 _help_misc_group_clones;Group all clones of a game under one single list entry
 _help_misc_hide_brackets;Hide text in brackets when showing game titles
 _help_misc_prefix_modes;Move "The" and "Vs." prefixes to the end of the game title
-_help_misc_hide_console;Hide console on startup. Note that this only works if starting Attract-Mode from a Windows GUI. If started from an existing console window (e.g. a batch file) then the process will always "attach" to the existing console and output to it
-_help_misc_image_cache_mbytes;Configure the maximum size of Attract-Mode's internal image cache (in megabytes)
-_help_misc_language;Select the language to use in Attract-Mode's user interface
+_help_misc_hide_console;Hide console on startup. Note that this only works if starting Attract-Mode Plus from a Windows GUI. If started from an existing console window (e.g. a batch file) then the process will always "attach" to the existing console and output to it
+_help_misc_image_cache_mbytes;Configure the maximum size of Attract-Mode Plus's internal image cache (in megabytes)
+_help_misc_language;Select the language to use in Attract-Mode Plus's user interface
 _help_misc_layout_preview;Show layout configuration changes immediately
-_help_misc_multiple_monitors;Enable the use of multiple monitors by Attract-Mode.  Setting this to "No" may reduce screen flicker when launching games
+_help_misc_multiple_monitors;Enable the use of multiple monitors by Attract-Mode Plus.  Setting this to "No" may reduce screen flicker when launching games
 _help_misc_power_saving;Helps to save power by only redrawing the screen when it's necessary. May cause animation stuttering on some layouts, or freezing on Linux
 _help_misc_quick_menu;Set whether menus can be opened and closed using the same button.  Also enables switching between menus without having to close them first
 _help_misc_screen_rotation;Set the base rotation of the screen
-_help_misc_startup_mode;Set what should happen when Attract-Mode first starts up
-_help_misc_track_usage;Configure whether Attract-Mode should track usage (played time and play count for each game)
-_help_misc_ui_color;Select the colour to use in Attract-Mode's user interface
+_help_misc_startup_mode;Set what should happen when Attract-Mode Plus first starts up
+_help_misc_track_usage;Configure whether Attract-Mode Plus should track usage (played time and play count for each game)
+_help_misc_ui_color;Select the colour to use in Attract-Mode Plus's user interface
 _help_misc_video_decoder;Configure the decoder to use for video playback (if multiple decoders are available)
-_help_misc_window_mode;Set whether Attract-Mode fills the screen or runs in a window
+_help_misc_window_mode;Set whether Attract-Mode Plus fills the screen or runs in a window
 _help_plugin_command;The executable associated with this plug-in
 _help_plugin_enabled;Set whether this plug-in is enabled
 _help_plugin_name;Configure Plugin

--- a/resources/language/es.msg
+++ b/resources/language/es.msg
@@ -57,8 +57,8 @@ Emulators;Emuladores
 #Enable Multiple Monitors;
 Enabled;activado
 #Exception;
-Exit Attract-Mode;Salir de Attract-Mode
-Exit Attract-Mode?;Salir de Attract-Mode?
+Exit Attract-Mode Plus;Salir de Attract-Mode Plus
+Exit Attract-Mode Plus?;Salir de Attract-Mode Plus?
 Exit Command;Comando de salida
 #Exit Message;
 Filter Name;Nombre del filtro
@@ -270,7 +270,7 @@ Generating Rom List: $1%;Generación de lista de roms: $1%
 
 # -- confirm_dialog --
 #Add '$1' to Favourites?;
-#Attract-Mode detected emulator(s) that can be imported automatically.  Import them now?;
+#Attract-Mode Plus detected emulator(s) that can be imported automatically.  Import them now?;
 #Auto-detect emulators?;
 #Clear Hotkey?;
 Delete display '$1'?;¿Desea borrar la pantalla '$1'?
@@ -427,12 +427,12 @@ _help_emu_add;Agrega un nuevo emulador
 _help_emu_args;Argumento de linea de comandos usado por este emulador.  Los siguientes pueden ser propiamente sustituidos: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn]
 _help_emu_delete;Borra la entrada para este emulador
 _help_emu_executable;Ruta completa y nombre del ejecutable del emulador. $HOME es reemplazado por con el directorio home del usuario
-_help_emu_exit_hotkey;Configura una tecla global para salir del emulador. Attract-Mode terminará el proceso del emulador si esta tecla es presionada
+_help_emu_exit_hotkey;Configura una tecla global para salir del emulador. Attract-Mode Plus terminará el proceso del emulador si esta tecla es presionada
 _help_emu_gen_romlist;Genera una lista de roms buscando en las rutas de roms configuradas con las extensiones configuradas, incorporando XML e importando información adicional a la lista generada (si está disponible)
 _help_emu_import_extras;Ruta de cualquier archivo adicional que neceiste ser leido cuando se genera la lista de roms para este emulador.  Los archivos soportados son: catver.ini (para categorias de juegos) y nplayers.ini (para el número de jugadores). Es posible ingresar multiples rutas separadas por punto y coma.
 _help_emu_info_source;Use "listxml" si el emulador prove la salida de mame -listxml, "listsoftware" para la salida de mame/mess -listsoftware, "thegamesdb.net" para extraer información desde thegamesdb.net, o "steam" para leer desde una instalación de steam.  "listsoftware" y "thegamesdb.net" también requieren que sea configurado un identificador de sistema reconocible por esas fuentes
 #_help_emu_name;
-_help_emu_nb_mode_wait;Configura un tiempo mínimo de ejecución (en segundos).  Attract-Mode esperará después de ejecutar este emulador hasta que haya transcurrido el tiempo mínimo de ejecución y pasará a ejecución de fondo. Esto necesita ser configurado por Steam para funcionar correctamente en Windows. Configure esto en 0 a menos que sepa que lo necesita
+_help_emu_nb_mode_wait;Configura un tiempo mínimo de ejecución (en segundos).  Attract-Mode Plus esperará después de ejecutar este emulador hasta que haya transcurrido el tiempo mínimo de ejecución y pasará a ejecución de fondo. Esto necesita ser configurado por Steam para funcionar correctamente en Windows. Configure esto en 0 a menos que sepa que lo necesita
 #_help_emu_pause_hotkey;
 _help_emu_romext;Extensión(es) para este emulador (por ej. .zip). Es posible ingresar multiples extensiones separadas por punto y coma. Especificar "<DIR>" como entrada si los juegos se encuientran en subdirectorios separados
 _help_emu_rompath;Ruta a las roms para este emulador.  Es posible ingresar multiples rutas separadas por punto y coma.
@@ -464,8 +464,8 @@ _help_input_add;Agrega una nueva asignación de controles para esta acción
 _help_input_delete;Remover esta asignación de controles
 #_help_layout_file;
 #_help_layout_name;
-_help_main_control;Configura las entradas de palanca, teclado y ratón que controlan Attract-Mode
-_help_main_display;Configura los grupos de lista de roms/temas ("Pantallas") que están disponibles para hacer circular enAttract-Mode
+_help_main_control;Configura las entradas de palanca, teclado y ratón que controlan Attract-Mode Plus
+_help_main_display;Configura los grupos de lista de roms/temas ("Pantallas") que están disponibles para hacer circular enAttract-Mode Plus
 _help_main_emu;Configurar configuraciones del emulador
 #_help_main_intro;
 _help_main_misc;Configuraciones varias
@@ -477,7 +477,7 @@ _help_main_sound;Configura volumenes de sonidos, asignaciones de eventos de soni
 #_help_misc_anisotropic_filtering;
 #_help_misc_antialiasing;
 #_help_misc_check_for_updates;
-_help_misc_confirm_exit;Confirm before exiting Attract-Mode?
+_help_misc_confirm_exit;Confirm before exiting Attract-Mode Plus?
 _help_misc_confirm_favs;Confirma la adición/remoción a favoritos
 _help_misc_exit_command;Comando seleccionado cuando Salir (con confirmación) es seleccionado [por ej. "sudo shutdown"]
 #_help_misc_exit_message;
@@ -493,10 +493,10 @@ _help_misc_hide_brackets;Esconde Hide el texto en paréntesis cuando se muestran
 _help_misc_quick_menu;Establece si los menús se pueden abrir y cerrar con el mismo botón. También permite cambiar entre menús sin tener que cerrarlos primero
 #_help_misc_screen_rotation;
 #_help_misc_startup_mode;
-_help_misc_track_usage;Configura si Attract-Mode debería registrar el uso (tiempo jugado y cuenta de partidas para cada juego)
+_help_misc_track_usage;Configura si Attract-Mode Plus debería registrar el uso (tiempo jugado y cuenta de partidas para cada juego)
 #_help_misc_ui_color;
 #_help_misc_video_decoder;
-_help_misc_window_mode;configura si Attract-Mode llena lapantalla o se ejecuta en una ventana
+_help_misc_window_mode;configura si Attract-Mode Plus llena lapantalla o se ejecuta en una ventana
 _help_plugin_command;Ejecutable asociado a este plugin
 _help_plugin_enabled;Configura si este plugin está o no habilitado
 #_help_plugin_name;

--- a/resources/language/fr.msg
+++ b/resources/language/fr.msg
@@ -57,8 +57,8 @@ Emulators;Emulateurs
 #Enable Multiple Monitors;
 Enabled;Activé
 #Exception;
-Exit Attract-Mode;Quitter Attract-Mode
-Exit Attract-Mode?;Quitter Attract-Mode?
+Exit Attract-Mode Plus;Quitter Attract-Mode Plus
+Exit Attract-Mode Plus?;Quitter Attract-Mode Plus?
 Exit Command;Commande de sortie
 #Exit Message;
 Filter Name;Nom du filtre
@@ -270,7 +270,7 @@ Scraping Artwork: $1%;Aspire l'Artwork: $1%
 
 # -- confirm_dialog --
 #Add '$1' to Favourites?;
-#Attract-Mode detected emulator(s) that can be imported automatically.  Import them now?;
+#Attract-Mode Plus detected emulator(s) that can be imported automatically.  Import them now?;
 #Auto-detect emulators?;
 #Clear Hotkey?;
 Delete display '$1'?;Supprimer la liste '$1'?
@@ -371,8 +371,8 @@ _help_control_custom6;Définit le(s) contrôle(s) utilisateur(s) "Custom6"
 _help_control_displays_menu;Définit le(s) contrôle(s) qui affiche(nt) la liste des listes
 _help_control_down;Définit le(s) contrôle(s) qui décrémente(nt) la séléction d'une valeur
 #_help_control_edit_game;
-_help_control_exit_to_desktop;Définit le(s) contrôle(s) qui quitte(nt) immédiatement Attract Mode pour revenir au bureau
-_help_control_exit;Définit le(s) contrôle(s) qui quitte(nt) Attract Mode
+_help_control_exit_to_desktop;Définit le(s) contrôle(s) qui quitte(nt) immédiatement Attract-Mode Plus pour revenir au bureau
+_help_control_exit;Définit le(s) contrôle(s) qui quitte(nt) Attract-Mode Plus
 _help_control_filters_menu;Définit le(s) contrôle(s) qui affiche(nt) la liste des filtres
 #_help_control_insert_game;
 #_help_control_intro;
@@ -398,7 +398,7 @@ _help_control_reload;Définit le(s) contrôle(s) qui rechargent la mise en page 
 _help_control_replay_last_game;Définit le(s) contrôle(s) qui relance(nt) le dernier jeu joué
 #_help_control_right;
 _help_control_screen_saver;Définit le(s) contrôle(s) qui lance(nt) le mode "économiseur d'écran"
-_help_control_screenshot;Définit le(s) contrôle(s) qui enregistre(nt) une impression écran d'Attract Mode
+_help_control_screenshot;Définit le(s) contrôle(s) qui enregistre(nt) une impression écran d'Attract-Mode Plus
 _help_control_select;Définit le(s) contrôle(s) qui valide(nt) la valeur sélectionnée
 _help_control_toggle_flip;Définit le(s) contrôle(s) qui active(nt)/désactive(nt) la rotation de l'écran de 180 degrés
 _help_control_toggle_layout;Définit le(s) contrôle(s) qui  active(nt)/désactive(nt) le script du theme utilisé (Ceci dépend du theme que vous utilisez)
@@ -427,12 +427,12 @@ _help_emu_add;Ajouter un nouvel émulateur
 _help_emu_args;Arguments de la ligne de commande de cet émulateur. Options de substitution: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn]
 _help_emu_delete;Supprime l'entrée pour cet émulateur
 _help_emu_executable;Chemin et nom de l'exécutable de l'émulateur. $HOME sera remplacé par le répertoire de l'utilisateur
-_help_emu_exit_hotkey;Définit un raccourci clavier pour sortir de l'émulateur. Attract-Mode arrêtera le process de l'émulateur lorsque ce raccourci clavier sera pressé.
+_help_emu_exit_hotkey;Définit un raccourci clavier pour sortir de l'émulateur. Attract-Mode Plus arrêtera le process de l'émulateur lorsque ce raccourci clavier sera pressé.
 _help_emu_gen_romlist;Génére une liste de ROM en cherchant dans le chemin des ROM avec l'extension choisie, incorporant l'XML et les fichiers additionnels d'information dans la liste générée (si disponible)
 _help_emu_import_extras;Fichiers additionels nécessitant d'être lus lors de la génération de la liste de ROM pour cet émulateur. Fichiers supportés: catver.ini (catégories) et nplayers.ini (nombre de joueur). Plusieurs fichiers peuvent être saisis si séparés par un point-virgule
 _help_emu_info_source;Saisir "listxml" si cet émulateur propose un fichier de type mame -listxml, "listsoftware" pour les fichiers du type mame/mess -listsoftware, "thegamesdb.net" pour extraire les informations du site thegamesdb.net, ou "steam" pour les lires depuis une installation de steam. Les sources "listsoftware" et "thegamesdb.net" nécessitent que des identifiants systèmes spécifiques soient configurés pour fonctionner correctement
 #_help_emu_name;
-_help_emu_nb_mode_wait;Définit un temps minimum de fonctionnement (en secondes). Attract-Mode va attendre, après avoir lancé l'émulateur, que ce temps minimum se soit écoulé avant de re-basculer au premier plan. Ceci est nécessaire pour que Steam fonctionne correctement sous Windows. Saisir 0 si vous n'en avez pas besoin
+_help_emu_nb_mode_wait;Définit un temps minimum de fonctionnement (en secondes). Attract-Mode Plus va attendre, après avoir lancé l'émulateur, que ce temps minimum se soit écoulé avant de re-basculer au premier plan. Ceci est nécessaire pour que Steam fonctionne correctement sous Windows. Saisir 0 si vous n'en avez pas besoin
 #_help_emu_pause_hotkey;
 _help_emu_romext;Extension des ROM pour cet émulateur (ex .zip).  Possibilité d'utiliser des extensions multiples séparées par un point-virgule
 _help_emu_rompath;Chemin des ROM pour cet émulateur
@@ -477,7 +477,7 @@ _help_main_sound;Configurer le volume et les affectations sonores
 #_help_misc_anisotropic_filtering;
 #_help_misc_antialiasing;
 #_help_misc_check_for_updates;
-_help_misc_confirm_exit;Confirm before exiting Attract-Mode?
+_help_misc_confirm_exit;Confirm before exiting Attract-Mode Plus?
 _help_misc_confirm_favs;Confirmer l'addition/suppression des favoris
 _help_misc_exit_command;Commande à exécuter en quittant (Confirmer) [exemple "sudo shutdown"]
 #_help_misc_exit_message;
@@ -493,10 +493,10 @@ _help_misc_language;Sélectionner la langue
 _help_misc_quick_menu;Permet d'ouvrir et de fermer les menus avec le même bouton. Permet également de passer d'un menu à l'autre sans avoir à les fermer au préalable
 #_help_misc_screen_rotation;
 #_help_misc_startup_mode;
-_help_misc_track_usage;Active les compteurs d'Attract-Mode (Compteur de jeu et Temps de jeu)
+_help_misc_track_usage;Active les compteurs d'Attract-Mode Plus (Compteur de jeu et Temps de jeu)
 #_help_misc_ui_color;
 #_help_misc_video_decoder;
-_help_misc_window_mode;Définit si Attract Mode rempli l'écran, fonctionne en mode plein écran ou si il s'exécute dans une fenêtre.
+_help_misc_window_mode;Définit si Attract-Mode Plus rempli l'écran, fonctionne en mode plein écran ou si il s'exécute dans une fenêtre.
 _help_plugin_command;Exécutable associé à ce plug-in
 _help_plugin_enabled;Indiquer si ce plug-in est activé
 #_help_plugin_name;

--- a/resources/language/it.msg
+++ b/resources/language/it.msg
@@ -57,8 +57,8 @@ Emulators;Emulatori
 Enable Multiple Monitors;Abilita monitor multipli
 Enabled;Attivo
 Exception;Eccezione
-Exit Attract-Mode;Esci da Attract-Mode
-Exit Attract-Mode?;Uscire da Attract-Mode?
+Exit Attract-Mode Plus;Esci da Attract-Mode Plus
+Exit Attract-Mode Plus?;Uscire da Attract-Mode Plus?
 Exit Command;Comando per uscire
 #Exit Message;
 Filter Name;Nome del filtro
@@ -270,7 +270,7 @@ Scraping Artwork: $1%;Sto recuperando le immagini: $1%
 
 # -- confirm_dialog --
 Add '$1' to Favourites?;Aggiungo '$1' ai preferiti?
-#Attract-Mode detected emulator(s) that can be imported automatically.  Import them now?;
+#Attract-Mode Plus detected emulator(s) that can be imported automatically.  Import them now?;
 #Auto-detect emulators?;
 #Clear Hotkey?;
 Delete display '$1'?;Cancello il display '$1'?
@@ -427,12 +427,12 @@ _help_emu_add;Aggiungere un nuovo emulatore
 _help_emu_args;Gli argomenti della linea di comando di questo emulatore. I seguenti parametri verranno sostituiti appropriatamente: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn]
 _help_emu_delete;Cancella le impostazioni di questo emulatore
 _help_emu_executable;Percorso completo e nome dell'eseguibile dell'emulatore. $HOME verrà rimpiazzato con la home directory dell'utente
-_help_emu_exit_hotkey;Configura una hotkey per uscire dall'emulatore. Attract-Mode terminerà l'emulatore se questa hotkey verrà premuta
+_help_emu_exit_hotkey;Configura una hotkey per uscire dall'emulatore. Attract-Mode Plus terminerà l'emulatore se questa hotkey verrà premuta
 _help_emu_gen_romlist;Genera la lista di ROM cercando all'interno dei percorsi indicati file con le estensioni specificate, incorporando anche le informazioni recuperate dai file aggiuntivi quando disponibili
 _help_emu_import_extras;Percorso per ogni file aggiuntivo che deve essere letto quando viene generata una lista di ROM per questo emulatore. I file supportati sono: catver.ini (per le categorie dei giochi), nplayers.ini (per il numero dei giocatori) e mame.xml. Possono essere specificate più directory separandole con il punto e virgola.
 _help_emu_info_source;Usare "listxml" se l'emulatore restituisce un output compatibile MAME -listxml, "listsoftware" per le liste software compatibili mame/mess -listsoftware, "thegamesdb.net" per recuperare le informazioni da thegamesdb.net, o "steam" per leggere da una installazione Steam, o "scummvm" se l'emulatore è ScummVM.  "listsoftware" e "thegamesdb.net" richiedono che venga configurato un identificatore di sistema riconosciuto da queste sorgenti.
 #_help_emu_name;
-_help_emu_nb_mode_wait;Configura un tempo mínimo di esecuzione (in secondi).  Attract-Mode aspetterà dopo aver eseguito l'emulatore finché è scaduto il tempo minimo, dopodiché passerà in primo piano. Questo deve essere impostato con Steam per funzionare correttamente su Windows. Impostare questo valore a 0 a meno che non si sappia quello che si fa.
+_help_emu_nb_mode_wait;Configura un tempo mínimo di esecuzione (in secondi).  Attract-Mode Plus aspetterà dopo aver eseguito l'emulatore finché è scaduto il tempo minimo, dopodiché passerà in primo piano. Questo deve essere impostato con Steam per funzionare correttamente su Windows. Impostare questo valore a 0 a meno che non si sappia quello che si fa.
 #_help_emu_pause_hotkey;
 _help_emu_romext;Estensioni dei file ROM per questo emulatore (per es. .zip) Più estensioni possono essere inserite utilizzando il punto e virgola. Specificare "<DIR>" come valore se i giochi sono memorizzati in sottodirectory separate.
 _help_emu_rompath;Percorsi per le ROM di questo emulatore. Possono essere specificate più directory separandole con il punto e virgola.
@@ -464,8 +464,8 @@ _help_input_default_action;Configura l'azione predefinita per questo controllo
 _help_input_delete;Cancella questa associazione dei tasti
 #_help_layout_file;
 #_help_layout_name;
-_help_main_control;Configura gli input di joystick, tastiera e mouse per controllare Attract-Mode
-_help_main_display;I display sono associazioni lista di ROM/tema che possono essere utilizzati in Attract-Mode per visualizzare liste di giochi e selezionare quello che si vuole giocare
+_help_main_control;Configura gli input di joystick, tastiera e mouse per controllare Attract-Mode Plus
+_help_main_display;I display sono associazioni lista di ROM/tema che possono essere utilizzati in Attract-Mode Plus per visualizzare liste di giochi e selezionare quello che si vuole giocare
 _help_main_emu;Configura le impostazioni degli emulatori
 _help_main_intro;Configura il video di introduzione
 _help_main_misc;Configurazioni varie
@@ -477,7 +477,7 @@ _help_main_sound;Configura il volume dei suoni, l'associazione dei suoni agli ev
 #_help_misc_anisotropic_filtering;
 #_help_misc_antialiasing;
 #_help_misc_check_for_updates;
-_help_misc_confirm_exit;Permette di chiedere la conferma prima di uscire da Attract-Mode
+_help_misc_confirm_exit;Permette di chiedere la conferma prima di uscire da Attract-Mode Plus
 _help_misc_confirm_favs;Conferma l'aggiunta/rimozione del gioco dai preferiti
 _help_misc_exit_command;Comando da eseguire quando viene selezionata l'uscita dal programma (con conferma) [per es. "sudo shutdown"]
 #_help_misc_exit_message;
@@ -486,15 +486,15 @@ _help_misc_filter_wrap_mode;Configura cosa succede quando i comandi "Filtro succ
 _help_misc_hide_brackets;Nasconde il testo tra parentesi quando viene mostrato il titolo del gioco
 #_help_misc_hide_console;
 #_help_misc_image_cache_mbytes;
-_help_misc_language;Seleziona la lingua dell'interfaccia di Attract-Mode
+_help_misc_language;Seleziona la lingua dell'interfaccia di Attract-Mode Plus
 #_help_misc_layout_preview;
 _help_misc_multiple_monitors;Abilita l'utilizzo di monitor multipli
 #_help_misc_power_saving;
 _help_misc_quick_menu;Imposta se i menu possono essere aperti e chiusi con lo stesso pulsante. Permette anche di passare da un menu all'altro senza doverli prima chiudere
 #_help_misc_screen_rotation;
-_help_misc_startup_mode;Configura come si deve comportare Attract-Mode quando viene eseguito
-_help_misc_track_usage;Configura se Attract-Mode deve gestire le statistiche di utilizzo (tempo complessivo e numero di partite giocate per ciascun titolo)
-_help_misc_ui_color;Seleziona il colore da utilizzare nell'interfaccia utente di Attract-Mode
+_help_misc_startup_mode;Configura come si deve comportare Attract-Mode Plus quando viene eseguito
+_help_misc_track_usage;Configura se Attract-Mode Plus deve gestire le statistiche di utilizzo (tempo complessivo e numero di partite giocate per ciascun titolo)
+_help_misc_ui_color;Seleziona il colore da utilizzare nell'interfaccia utente di Attract-Mode Plus
 _help_misc_video_decoder;Configura il decoder da utilizzare per riprodurre i video (nel caso siano disponibili più decoder)
 _help_misc_window_mode;Configura se il frontend deve lavorare a tutto schermo o essere eseguito in una finestra
 _help_plugin_command;Eseguibile associato a questo plugin

--- a/resources/language/jp.msg
+++ b/resources/language/jp.msg
@@ -57,8 +57,8 @@ Emulators;エミュレータ
 #Enable Multiple Monitors;
 Enabled;使用する
 #Exception;
-Exit Attract-Mode;プログラムを終了
-Exit Attract-Mode?;終了しますか?
+Exit Attract-Mode Plus;プログラムを終了
+Exit Attract-Mode Plus?;終了しますか?
 Exit Command;終了コマンド
 #Exit Message;
 Filter Name;フィルターの名前
@@ -270,7 +270,7 @@ Scraping Artwork: $1%;オンラインから $1% をダウンロード中です
 
 # -- confirm_dialog --
 #Add '$1' to Favourites?;
-#Attract-Mode detected emulator(s) that can be imported automatically.  Import them now?;
+#Attract-Mode Plus detected emulator(s) that can be imported automatically.  Import them now?;
 #Auto-detect emulators?;
 #Clear Hotkey?;
 Delete display '$1'?;ディスプレイ '$1' を削除してもよろしいですか？
@@ -477,7 +477,7 @@ _help_main_sound;効果音, 背景音楽, ボリューム等を設定します
 #_help_misc_anisotropic_filtering;
 #_help_misc_antialiasing;
 #_help_misc_check_for_updates;
-_help_misc_confirm_exit;Confirm before exiting Attract-Mode?
+_help_misc_confirm_exit;Confirm before exiting Attract-Mode Plus?
 _help_misc_confirm_favs;お気に入りのゲームを追加,削除する時, Yes/Noで確認するかを設定します
 _help_misc_exit_command;終了 (Yes/No 確認) でプログラムを終了する時に実行する外部コマンドを設定します (例. "sudo shutdown")
 #_help_misc_exit_message;
@@ -496,7 +496,7 @@ _help_misc_quick_menu;同じボタンでメニューを開いたり閉じたり�
 _help_misc_track_usage;ゲームのプレイ内容(プレイ数,プレイ時間)を記録するかを設定します.
 #_help_misc_ui_color;
 #_help_misc_video_decoder;
-_help_misc_window_mode;.Attract-Mode がウィンドウモードで起動するかフルスクリーンモードで起動するかを設定します
+_help_misc_window_mode;.Attract-Mode Plus がウィンドウモードで起動するかフルスクリーンモードで起動するかを設定します
 _help_plugin_command;プラグインのコマンドを設定します
 _help_plugin_enabled;プラグインを使うかを設定します
 #_help_plugin_name;

--- a/resources/language/kr.msg
+++ b/resources/language/kr.msg
@@ -57,8 +57,8 @@ Emulators;에뮬레이터
 Enable Multiple Monitors;다중 모니터 사용
 Enabled;활성화 여부
 Exception;예외 규칙
-Exit Attract-Mode;프로그램 종료
-Exit Attract-Mode?;종료하시겠습니까?
+Exit Attract-Mode Plus;프로그램 종료
+Exit Attract-Mode Plus?;종료하시겠습니까?
 Exit Command;종료 명령어
 #Exit Message;
 Filter Name;필터 이름
@@ -270,7 +270,7 @@ Scraping Artwork: $1%;온라인에서 $1% 을 다운로드하는 중입니다
 
 # -- confirm_dialog --
 Add '$1' to Favourites?;'$1' 게임을 즐겨하는 목록에 추가하겠습니까?
-#Attract-Mode detected emulator(s) that can be imported automatically.  Import them now?;
+#Attract-Mode Plus detected emulator(s) that can be imported automatically.  Import them now?;
 #Auto-detect emulators?;
 #Clear Hotkey?;
 Delete display '$1'?;'$1' 목록을 제거하시겠습니까?
@@ -484,7 +484,7 @@ _help_misc_exit_command;확인 후 종료 명령으로 프로그램을 끌 때 �
 _help_misc_filter_wrap_mode;목록의 마지막 필터에서 '다음 필터' 키가 입력되었을 때 처리 방식을 결정합니다.
 #_help_misc_group_clones;
 _help_misc_hide_brackets;게임 제목을 표시할 때에, 괄호로 둘러싸인 부분은 표시하지 않을 지 여부를 설정합니다
-_help_misc_hide_console;콘솔 창을 숨깁니다. 이 옵션은 프로그램을 윈도우 GUI상에서 실행할 때에만 적용됩니다. 이미 띄워진 콘솔 창에서 실행하는 경우 (예: 배치 파일에서 실행하는 경우) Attract-Mode 프로세스는 해당 창에 달라붙을 것입니다.
+_help_misc_hide_console;콘솔 창을 숨깁니다. 이 옵션은 프로그램을 윈도우 GUI상에서 실행할 때에만 적용됩니다. 이미 띄워진 콘솔 창에서 실행하는 경우 (예: 배치 파일에서 실행하는 경우) Attract-Mode Plus 프로세스는 해당 창에 달라붙을 것입니다.
 #_help_misc_image_cache_mbytes;
 _help_misc_language;언어를 설정합니다
 #_help_misc_layout_preview;
@@ -494,7 +494,7 @@ _help_misc_quick_menu;같은 버튼을 사용하여 메뉴를 열고 닫을 수 
 #_help_misc_screen_rotation;
 _help_misc_startup_mode;프로그램이 처음 실행될 때 무엇을 해야하는 지를 설정합니다
 _help_misc_track_usage;플레이 내역 (플레이 횟수, 시간) 을 기록할지 설정합니다.
-_help_misc_ui_color;Attract-Mode의 사용자 인터페이스에 사용할 색상을 선택하세요.
+_help_misc_ui_color;Attract-Mode Plus의 사용자 인터페이스에 사용할 색상을 선택하세요.
 _help_misc_video_decoder;영상을 재생하는 데 사용할 디코더를 선택합니다
 _help_misc_window_mode;창 모드로 동작할지 전체 화면으로 동작할지를 설정합니다.
 _help_plugin_command;플러그 인의 실행 파일을 지정합니다

--- a/resources/language/tw.msg
+++ b/resources/language/tw.msg
@@ -57,8 +57,8 @@ Emulators;模擬器
 Enable Multiple Monitors;啟用多螢幕支援
 Enabled;啟用
 Exception;例外條件
-Exit Attract-Mode;結束 Attract-Mode
-Exit Attract-Mode?;要結束 Attract-Mode 嗎？
+Exit Attract-Mode Plus;結束 Attract-Mode Plus
+Exit Attract-Mode Plus?;要結束 Attract-Mode Plus 嗎？
 Exit Command;結束時指令
 Exit Message;結束時訊息
 Filter Name;過濾名稱
@@ -270,7 +270,7 @@ Scraping Artwork: $1%;正在搜刮插圖: $1%
 
 # -- confirm_dialog --
 Add '$1' to Favourites?;要將「$1」加入我的最愛嗎？
-Attract-Mode detected emulator(s) that can be imported automatically.  Import them now?;Attract-Mode 已偵測到能夠自動匯入的模擬器，要立即匯入嗎？
+Attract-Mode Plus detected emulator(s) that can be imported automatically.  Import them now?;Attract-Mode Plus 已偵測到能夠自動匯入的模擬器，要立即匯入嗎？
 #Auto-detect emulators?;
 Clear Hotkey?;要清除熱鍵嗎？
 Delete display '$1'?;要刪除「$1」顯示介面嗎？
@@ -372,11 +372,11 @@ _help_control_displays_menu;設定「顯示主選單」的控制鍵
 _help_control_down;設定「下移選項」的控制鍵
 _help_control_edit_game;設定「編輯當前選項」的控制鍵
 _help_control_exit_to_desktop;設定「結束並立即返回桌面」的控制鍵
-_help_control_exit;設定「結束 Attract-Mode」的控制鍵
+_help_control_exit;設定「結束 Attract-Mode Plus」的控制鍵
 _help_control_filters_menu;設定「顯示遊戲過濾選單」的控制鍵
 #_help_control_insert_game;
 _help_control_intro;設定「顯示啟動視訊」的控制鍵
-_help_control_joystick_map;指定電腦的搖桿裝置在 Attract-Mode 裡的搖桿順序 (例: 你可以強制這個前導永遠使用 "Microsoft X-Box 360 pad" 作為搖桿 0)
+_help_control_joystick_map;指定電腦的搖桿裝置在 Attract-Mode Plus 裡的搖桿順序 (例: 你可以強制這個前導永遠使用 "Microsoft X-Box 360 pad" 作為搖桿 0)
 _help_control_joystick_threshold;這個設定用來定位搖桿移動的靈敏度，數值從 1 到 100 (100 為最大值)。
 #_help_control_layout_options;
 _help_control_left;設定「左移選項」的控制鍵
@@ -426,14 +426,14 @@ _help_displaysmenu;設定主選單的設定選項
 _help_emu_add;新增一個新的模擬器
 _help_emu_args;這個模擬器的命令行參數 (可用的變數: [name]、[romext]、[rompath]、[emulator]、[romfilename]、[system]、[systemn]、[workdir]、[nothing]，以及任何有效的其它標記，詳情請參考 layout 文件)
 _help_emu_delete;刪除這個模擬器項目
-_help_emu_executable;這個模擬器的完整路徑及檔名 (可用的變數: $HOME = 用戶主目錄、$PROGDIR = Attract-Mode 程式目錄，Windows 系統額外還有符合系統環境變數的 %SYSTEMROOT% 及 %PROGRAMFILES% 可以使用)
-_help_emu_exit_hotkey;設定一個全域熱鍵來結束模擬器 (當這個熱鍵按下時，Attract-Mode 將會終結這個模擬器處理程序)
+_help_emu_executable;這個模擬器的完整路徑及檔名 (可用的變數: $HOME = 用戶主目錄、$PROGDIR = Attract-Mode Plus 程式目錄，Windows 系統額外還有符合系統環境變數的 %SYSTEMROOT% 及 %PROGRAMFILES% 可以使用)
+_help_emu_exit_hotkey;設定一個全域熱鍵來結束模擬器 (當這個熱鍵按下時，Attract-Mode Plus 將會終結這個模擬器處理程序)
 _help_emu_gen_romlist;使用設定裡的遊戲檔路徑、副檔名、XML 及附加匯入檔案裡的資料來產生遊戲清單
 _help_emu_import_extras;設定產生遊戲清單時所要使用的附加檔案路徑。 支援的檔案: catver.ini (遊戲分類)、nplayers.ini (玩家人數)、series.ini (系列遊戲)、language.ini (遊戲語言) 及 mame.xml (多個檔案路徑可用分號間隔)
 _help_emu_info_source;使用 "listxml" 為 mame -listxml 輸出、"listsoftware" 為 mame/mess -listsoftware 輸出、"thegamesdb.net" 為從 thegamesdb.net 搜刮資料、"steam" 為從 steam 安裝中讀取、"scummvm" 為當模擬器為 scummvm 時使用 (使用 "listsoftware" 及 "thegamesdb.net" 必須正確設定系統識別名稱)
 #_help_emu_name;
-_help_emu_nb_mode_wait;若此值非 0，這個模擬器將會執行在非阻塞模式 (Attract-Mode 將會等待至所設定的秒數後才將視窗焦點從模擬器轉回並喚醒 Attract-Mode，這對於正確啟動 Steam 之類的程序是必要的，在你了解它的作用前請保持為 0)
-_help_emu_pause_hotkey;設定一個全域熱鍵來暫停模擬器 (當這個熱鍵按下時，Attract-Mode 將會暫停這個模擬器處理程序並返回前導，這個模擬器處理程序可在再次選擇同樣遊戲後繼續)
+_help_emu_nb_mode_wait;若此值非 0，這個模擬器將會執行在非阻塞模式 (Attract-Mode Plus 將會等待至所設定的秒數後才將視窗焦點從模擬器轉回並喚醒 Attract-Mode Plus，這對於正確啟動 Steam 之類的程序是必要的，在你了解它的作用前請保持為 0)
+_help_emu_pause_hotkey;設定一個全域熱鍵來暫停模擬器 (當這個熱鍵按下時，Attract-Mode Plus 將會暫停這個模擬器處理程序並返回前導，這個模擬器處理程序可在再次選擇同樣遊戲後繼續)
 _help_emu_romext;這個模擬器的遊戲副檔名 (例: .zip)，若遊戲在個別的子目錄時請設為 "<DIR>" (多個副檔名可用分號間隔)
 _help_emu_rompath;這個模擬器的遊戲檔存放路徑 (多個路徑可用分號間隔)
 _help_emu_scrape_artwork;從網路搜刮這個模擬器所沒有的遊戲插圖
@@ -441,7 +441,7 @@ _help_emu_scrape_artwork;從網路搜刮這個模擬器所沒有的遊戲插圖
 _help_emu_sel_gen_romlist;為多個模擬器產生收藏集/遊戲清單
 _help_emu_sel;設定模擬器
 _help_emu_system;這個模擬器的系統識別名稱 (多個識別名稱可用分號間隔)
-_help_emu_workdir;這個模擬器的工作目錄 (Attract-Mode 會將工作目錄作為執行模擬器的開始位置，一些在這個前導裡以相對路徑所設定的資源路徑也都會以此工作目錄為開始位置)
+_help_emu_workdir;這個模擬器的工作目錄 (Attract-Mode Plus 會將工作目錄作為執行模擬器的開始位置，一些在這個前導裡以相對路徑所設定的資源路徑也都會以此工作目錄為開始位置)
 _help_filter_add_exception;新增例外條件至這個遊戲過濾 (若遊戲符合這個例外條件且未被先前的規則過濾到，它將會列在這個遊戲過濾裡)
 _help_filter_add_rule;新增一個規則至這個遊戲過濾 (遊戲必須符合所有過濾規則或例外條件才會列在這個遊戲過濾)
 _help_filter_delete;刪除這個遊戲過濾
@@ -458,14 +458,14 @@ _help_game_edit;編輯這個遊戲的資訊
 _help_game_overview;編輯遊戲簡介
 _help_generator_build;開始為已選擇的模擬器建立遊戲清單
 _help_generator_opt;設定要為哪些模擬器建立遊戲清單
-_help_input_action;目前所設定的 Attract-Mode 操作控制
+_help_input_action;目前所設定的 Attract-Mode Plus 操作控制
 _help_input_add;新增一個輸入映射給這個操作控制使用
 _help_input_default_action;設定這個操作控制的預設操作功能
 _help_input_delete;移除這個輸入映射
 _help_layout_file;一些畫面佈局主題提供多個 layout*.nut 檔案，須選擇要使用的畫面佈局檔案。
 #_help_layout_name;
-_help_main_control;設定搖桿、鍵盤及滑鼠按鍵用來操作 Attract-Mode 功能
-_help_main_display;設定遊戲清單/畫面佈局群組 (又稱顯示介面)，用於在 Attract-Mode 裡循環顯示。
+_help_main_control;設定搖桿、鍵盤及滑鼠按鍵用來操作 Attract-Mode Plus 功能
+_help_main_display;設定遊戲清單/畫面佈局群組 (又稱顯示介面)，用於在 Attract-Mode Plus 裡循環顯示。
 _help_main_emu;設定模擬器設定選項
 _help_main_intro;設定啟動視訊
 _help_main_misc;設定一般設定
@@ -477,26 +477,26 @@ _help_main_sound;設定聲音音量、操作事件聲音對映及環境音效
 #_help_misc_anisotropic_filtering;
 #_help_misc_antialiasing;
 #_help_misc_check_for_updates;
-_help_misc_confirm_exit;結束 Attract-Mode 前先確認？
+_help_misc_confirm_exit;結束 Attract-Mode Plus 前先確認？
 _help_misc_confirm_favs;加入/移除我的最愛前先確認？
-_help_misc_exit_command;設定當結束 Attract-Mode 時所要執行的命令 [例: "sudo shutdown"]
-_help_misc_exit_message;設定當結束 Attract-Mode 時所要顯示的訊息 [例: "關機"]
+_help_misc_exit_command;設定當結束 Attract-Mode Plus 時所要執行的命令 [例: "sudo shutdown"]
+_help_misc_exit_message;設定當結束 Attract-Mode Plus 時所要顯示的訊息 [例: "關機"]
 _help_misc_filter_wrap_mode;設定當使用「下一個遊戲過濾」或「上一個遊戲過濾」切換至底時所要執行的動作
 #_help_misc_group_clones;
 _help_misc_hide_brackets;顯示遊戲標題時隱藏括號內容
-_help_misc_hide_console;啟動時隱藏主控台視窗 (註: 這僅在從 Windows 介面啟動 Attract-Mode 時能正常運作，若從命令提示字元視窗啟動 (例: 批次檔)，這個處理程式將始終附加並輸出到這個命令提示字元視窗)
-_help_misc_image_cache_mbytes;設定 Attract-Mode 內部影像快取最大值大小 (以 MB 為單位)
-_help_misc_language;選擇 Attract-Mode 使用者介面所要使用的語言
+_help_misc_hide_console;啟動時隱藏主控台視窗 (註: 這僅在從 Windows 介面啟動 Attract-Mode Plus 時能正常運作，若從命令提示字元視窗啟動 (例: 批次檔)，這個處理程式將始終附加並輸出到這個命令提示字元視窗)
+_help_misc_image_cache_mbytes;設定 Attract-Mode Plus 內部影像快取最大值大小 (以 MB 為單位)
+_help_misc_language;選擇 Attract-Mode Plus 使用者介面所要使用的語言
 _help_misc_layout_preview;立即顯示佈局配置變更
-_help_misc_multiple_monitors;為 Attract-Mode 啟用多螢幕支援 (設定為「否」可能減少執行遊戲時的螢幕閃爍問題)
+_help_misc_multiple_monitors;為 Attract-Mode Plus 啟用多螢幕支援 (設定為「否」可能減少執行遊戲時的螢幕閃爍問題)
 _help_misc_power_saving;僅在需要時才重新繪製螢幕進而達成省電 (可能造成一些畫面佈局動畫卡頓或在 Linux 系統畫面凍結)
 _help_misc_quick_menu;設定是否可以使用相同按鈕開啟和關閉選單。還可以在選單之間切換，而無需先關閉它們
 #_help_misc_screen_rotation;
-_help_misc_startup_mode;設定 Attract-Mode 啟動時所要顯示的選單項目
-_help_misc_track_usage;設定 Attract-Mode 是否要記錄使用狀況 (每個遊戲的遊戲時間及遊戲次數)
-_help_misc_ui_color;選擇在 Attract-Mode 的使用者介面中使用的顏色
+_help_misc_startup_mode;設定 Attract-Mode Plus 啟動時所要顯示的選單項目
+_help_misc_track_usage;設定 Attract-Mode Plus 是否要記錄使用狀況 (每個遊戲的遊戲時間及遊戲次數)
+_help_misc_ui_color;選擇在 Attract-Mode Plus 的使用者介面中使用的顏色
 _help_misc_video_decoder;設定視訊播放時所要使用的解碼器 (若存在多個解碼器)
-_help_misc_window_mode;設定 Attract-Mode 所要使用的顯示模式
+_help_misc_window_mode;設定 Attract-Mode Plus 所要使用的顯示模式
 _help_plugin_command;這個外掛所關聯的外部執行檔
 _help_plugin_enabled;設定這個外掛是否要啟用
 #_help_plugin_name;
@@ -511,7 +511,7 @@ _help_scraper_marquees;設定是否要搜刮遊戲招牌插圖
 _help_scraper_snaps;設定是否要搜刮遊戲捉圖
 _help_scraper_vids;設定是否要搜刮遊戲視訊
 _help_scraper_wheels;設定是否要搜刮遊戲圖標 (輪播插圖)
-_help_shortcut_artwork_name;提供要與此捷徑關聯的插圖名稱 (Attract-Mode 將會在顯示這個捷徑時嘗試使用這個名稱載入插圖資源)
+_help_shortcut_artwork_name;提供要與此捷徑關聯的插圖名稱 (Attract-Mode Plus 將會在顯示這個捷徑時嘗試使用這個名稱載入插圖資源)
 _help_shortcut_delete;從遊戲清單刪除這個捷徑
 _help_shortcut_label;編輯這個捷徑的標題名稱
 _help_shortcut_target;編輯這個捷徑的目標顯示介面

--- a/src/fe_info.hpp
+++ b/src/fe_info.hpp
@@ -297,7 +297,7 @@ protected:
 };
 
 //
-// Class for storing information regarding a specific Attract-Mode display
+// Class for storing information regarding a specific display
 //
 class FeDisplayInfo : public FeBaseConfigurable
 {

--- a/src/fe_input.hpp
+++ b/src/fe_input.hpp
@@ -116,7 +116,7 @@ class FeInputMap : public FeBaseConfigurable
 public:
 
 	//
-	// Input actions supported by Attract-Mode:
+	// Supported Input actions:
 	//
 	// This enum needs to be kept in sync with commandStrings[] and
 	// commandDispStrings[] below.

--- a/src/fe_net.cpp
+++ b/src/fe_net.cpp
@@ -85,7 +85,7 @@ const FeNetTask &FeNetTask::operator=( const FeNetTask &o )
 
 bool FeNetTask::do_task( long *code )
 {
-	const char *UA_VALUE = "Attract-Mode/2.x";
+	const char *UA_VALUE = "Attract-Mode-Plus/3.x";
 
 	std::vector<char> rbuff;
 

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -437,7 +437,7 @@ void FeSettings::load()
 
 	if (( FE_DATA_PATH != NULL ) && ( !directory_exists( FE_DATA_PATH ) ))
 	{
-		FeLog() << "Warning: Attract-Mode was compiled to look for its default configuration files in: "
+		FeLog() << "Warning: Attract-Mode Plus was compiled to look for its default configuration files in: "
 			<< FE_DATA_PATH << ", which is not available." << std::endl;
 	}
 
@@ -1781,7 +1781,7 @@ bool FeSettings::load_game_extras(
 	if ( !in_file.is_open() )
 		return false;
 
-	// Before Attract-Mode v 2.4, Overviews were stored with game extras.
+	// Before v2.4, Overviews were stored with game extras.
 	//
 	// There is specific code here to clean up pre 2.4 game extras data (commented)
 	// this code is intended to be removed at some point in a future version
@@ -2539,14 +2539,14 @@ int FeSettings::exit_command() const
 void FeSettings::get_exit_message( std::string &exit_message ) const
 {
 	exit_message = m_exit_message.empty()
-		? _( "Exit Attract-Mode" )
+		? _( "Exit Attract-Mode Plus" )
 		: m_exit_message;
 }
 
 void FeSettings::get_exit_question( std::string &exit_question ) const
 {
 	exit_question = m_exit_message.empty()
-		? _( "Exit Attract-Mode?" )
+		? _( "Exit Attract-Mode Plus?" )
 		: m_exit_question;
 }
 

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -1154,7 +1154,7 @@ void unix_wait_process( unsigned int pid, run_program_options_class *opt )
 			//
 			if ( process_check_for_hotkey( opt, exit_is ) )
 			{
-				// Where the user has configured the "exit hotkey" in Attract-Mode to the same key as the emulator
+				// Where the user has configured the "exit hotkey" to the same key as the emulator
 				// uses to exit, we often have a problem of losing focus.  Delaying a bit and testing to make sure
 				// the emulator process is still running before sending the kill signal seems to help...
 				//

--- a/src/fe_util_android.cpp
+++ b/src/fe_util_android.cpp
@@ -58,7 +58,7 @@ namespace {
 
 					m_line += buf;
 
-					__android_log_write( ANDROID_LOG_DEBUG, "Attract-Mode", m_line.c_str() );
+					__android_log_write( ANDROID_LOG_DEBUG, "Attract-Mode-Plus", m_line.c_str() );
 					m_line.clear();
 				}
 				else
@@ -70,7 +70,7 @@ namespace {
 			}
 
 			if ( !m_line.empty() )
-				__android_log_write( ANDROID_LOG_DEBUG, "Attract-Mode2", m_line.c_str() );
+				__android_log_write( ANDROID_LOG_DEBUG, "Attract-Mode-Plus2", m_line.c_str() );
 		}
 
 	public:

--- a/src/fe_util_osx.hpp
+++ b/src/fe_util_osx.hpp
@@ -37,7 +37,7 @@ void osx_hide_menu_bar();
 std::basic_string<std::uint32_t> osx_clipboard_get_content();
 
 //
-// Put the focus on Attract-Mode.
+// Put the focus on the frontend.
 //
 void osx_take_focus();
 

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -2132,7 +2132,7 @@ bool FeVM::setup_wizard()
 
 	// return 0 if user confirms import
 	if ( m_overlay->confirm_dialog(
-		_( "Attract-Mode detected emulator(s) that can be imported automatically.  Import them now?" ),
+		_( "Attract-Mode Plus detected emulator(s) that can be imported automatically.  Import them now?" ),
 		true ) != 0 ) // default to "yes"
 	{
 		return false;
@@ -2766,7 +2766,7 @@ const char *FeVM::cb_get_art( const char *art, int index_offset, int filter_offs
 			retval = image_list.front();
 
 		// We force our return value to an absolute path, to work
-		// around Attract-Mode's tendency to assume that relative
+		// around the frontends tendency to assume that relative
 		// paths are relative to the layout directory.
 		//
 		// We are almost certain that is not the case here...

--- a/src/fe_window.cpp
+++ b/src/fe_window.cpp
@@ -310,14 +310,14 @@ void FeWindow::initial_create()
 
 	// Some Windows users are reporting emulators hanging/failing to get focus when launched
 	// from 'fullscreen' (fullscreen mode, fillscreen where window dimensions = screen dimensions)
-	// They also report that the same emulator does work when Attract-Mode is in one of its windowed
+	// They also report that the same emulator does work when the frontend is in one of its windowed
 	// modes.
 	//
 	// We work around this issue for these users by having the default "fillscreen" mode actually
 	// extend 1 pixel offscreen in each direction (-1, -1, scr_width+2, scr_height+2).  The expectation
 	// is that this will prevent Windows from giving the frontend window the "fullscreen mode" treatment
 	// which seems to be the cause of this issue.  This is actually the same behaviour that earlier
-	// versions of Attract-Mode had (first by design, then by accident).
+	// versions had (first by design, then by accident).
 	//
 	if ( m_win_mode == FeSettings::Fillscreen )
 	{
@@ -431,7 +431,7 @@ void FeWindow::initial_create()
     	m_window->setIcon({ icon.getSize().y, icon.getSize().y }, icon.getPixelsPtr() );
 #endif
 	// We need to clear and display here before calling setSize and setPosition
-	// to avoid a white window flash on launching Attract Mode.
+	// to avoid a white window flash on launch.
 	clear();
 	display();
 
@@ -489,7 +489,7 @@ void launch_callback( void *o )
 #if defined(USE_XLIB)
 		sf::sleep( sf::milliseconds( 1000 ) );
 #endif
-		FeDebug() << "Closing Attract-Mode window" << std::endl;
+		FeDebug() << "Closing Attract-Mode Plus window" << std::endl;
 		win->close(); // this fixes raspi version (w/sfml-pi) obscuring daphne (and others?)
 	}
 #endif
@@ -635,9 +635,8 @@ bool FeWindow::run()
 
 	//
 	// If nbm_wait > 0, then m_fes.run() above is non-blocking and we need
-	// to wait at most nbm_wait seconds for Attract-Mode to lose focus to
-	// the launched program.  If it loses focus, we continue waiting until
-	// focus returns to Attract-Mode
+	// to wait at most nbm_wait seconds to lose focus to the launched program.
+	// If it loses focus, we continue waiting until it returns
 	//
 	if ( nbm_wait > 0 )
 	{
@@ -661,7 +660,7 @@ bool FeWindow::run()
 			if (( timer.getElapsedTime() >= sf::seconds( nbm_wait ) )
 				&& ( has_focus ))
 			{
-				FeDebug() << "Attract-Mode has focus, stopped non-blocking wait after "
+				FeDebug() << "Attract-Mode Plus has focus, stopped non-blocking wait after "
 					<< timer.getElapsedTime().asSeconds() << "s" << std::endl;
 
 				done_wait = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,11 +130,10 @@ int main(int argc, char *argv[])
 	}
 
 #ifdef SFML_SYSTEM_WINDOWS
-	// Detect an nvidia card and if it's found create an nvidia profile
-	// for Attract Mode with optimizations
+	// Detect an nvidia card and if it's found create an nvidia profile for optimizations
 	if ( nvapi_init() > 0 )
-		FeLog() << "Nvidia GPU detected. Attract Mode profile was not found so it has been created.\n"
-				<< "In order for the changes to take effect, please restart Attract Mode\n" << std::endl;
+		FeLog() << "Nvidia GPU detected. Attract-Mode Plus profile was not found so it has been created.\n"
+				<< "In order for the changes to take effect, please restart Attract-Mode Plus\n" << std::endl;
 	FeDebug() << std::endl;
 #endif
 
@@ -1191,6 +1190,6 @@ int main(int argc, char *argv[])
 	curl_global_cleanup();
 #endif
 
-	FeDebug() << "Attract-Mode ended normally" << std::endl;
+	FeDebug() << "Attract-Mode Plus ended normally" << std::endl;
 	return 0;
 }

--- a/src/scraper_gamesdb.cpp
+++ b/src/scraper_gamesdb.cpp
@@ -688,7 +688,7 @@ bool FeSettings::thegamesdb_scraper( FeImporterContext &c )
 	path += "thegamesdb.net/";
 	confirm_directory( path, "" );
 
-	// Use public API key assigned to the Attract-Mode project if no specific key configured
+	// Use public API key assigned to this project if no specific key configured
 	//
 	std::string api_key = get_info( FeSettings::ThegamesdbKey );
 	if ( !api_key.empty() )

--- a/src/scraper_general.cpp
+++ b/src/scraper_general.cpp
@@ -625,7 +625,7 @@ bool FeSettings::build_romlist( const std::vector< FeImportTask > &task_list,
 
 			if ( tail_compare( (*itr).file_name, ".txt" ) )
 			{
-				// Attract-Mode format list
+				// Native format list
 				//
 				FeRomList temp_list( m_config_path );
 				temp_list.load_from_file( (*itr).file_name, ";" );

--- a/src/sprite.cpp
+++ b/src/sprite.cpp
@@ -2,8 +2,7 @@
  *  Portions of this file are from the SFML Project and are subject to the
  *  SFML copyright notice and license terms set out below.
  *
- *  All modifications to this file for the Attract-Mode frontend are subject
- *  to the Attract-Mode copyright notice and license terms set out below.
+ *  All modifications to this file are subject to the copyright notice and license terms set out below.
  *
  */
 

--- a/src/sprite.hpp
+++ b/src/sprite.hpp
@@ -2,8 +2,7 @@
  *  Portions of this file are from the SFML Project and are subject to the
  *  SFML copyright notice and license terms set out below.
  *
- *  All modifications to this file for the Attract-Mode frontend are subject
- *  to the Attract-Mode copyright notice and license terms set out below.
+ *  All modifications to this file are subject to the copyright notice and license terms set out below.
  *
  */
 

--- a/util/android/AndroidManifest.xml
+++ b/util/android/AndroidManifest.xml
@@ -13,12 +13,12 @@
     <uses-sdk android:minSdkVersion="9"
               android:targetSdkVersion="19" />
 
-    <application android:label="Attract-Mode"
+    <application android:label="Attract-Mode Plus"
                  android:hasCode="false"
                  android:allowBackup="true">
 
     <activity android:name="android.app.NativeActivity"
-              android:label="Attract-Mode"
+              android:label="Attract-Mode Plus"
               android:configChanges="keyboardHidden|orientation|screenSize">
 
         <meta-data android:name="android.app.lib_name" android:value="sfml-activity" />

--- a/util/android/Readme.md
+++ b/util/android/Readme.md
@@ -4,7 +4,7 @@ To build:
 
       https://github.com/SFML/SFML/wiki/Tutorial%3A-Building-SFML-for-Android
 
-2. from Attract-Mode's util/android directory, run the following commands:
+2. from the Attract-Mode Plus util/android directory, run the following commands:
 
       android update project --target "android-25" --path .
 

--- a/util/android/custom_rules.xml
+++ b/util/android/custom_rules.xml
@@ -2,7 +2,7 @@
 <project>
     <target name="-pre-compile">
 
-        <!-- copy Attract-Mode config files to assets -->
+        <!-- copy config files to assets -->
         <property name="config.dir" location="../../config" />
         <echo message="Copying '${config.dir}' to assets" />
 

--- a/util/lang.sh
+++ b/util/lang.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Attract-Mode language utility script
+# Attract-Mode Plus language utility script
 # - Updates *.msg files to match the master_msg file (en.msg)
 # - Additional translations will be placed at the end of their respective file
 # - All comments in the translation files will be lost

--- a/util/linux/attract-mode-plus.appdata.xml
+++ b/util/linux/attract-mode-plus.appdata.xml
@@ -3,12 +3,12 @@
   <id>attract-mode-plus.desktop</id>
   <metadata_license>CC0</metadata_license>
   <project_license>GPL-3.0+</project_license>
-  <name>Attract-Mode-Plus</name>
+  <name>Attract-Mode Plus</name>
   <summary>A graphical frontend for emulators</summary>
 
   <description>
     <p>
-      Attract-Mode is a graphical frontend for command line emulators such as MAME,
+      Attract-Mode Plus is a graphical frontend for command line emulators such as MAME,
       MESS and Nestopia. It hides the underlying operating system and is intended to
       be controlled with a joystick, gamepad or spinner, making it ideal for use
       in arcade cabinets.

--- a/util/linux/attract-mode-plus.desktop
+++ b/util/linux/attract-mode-plus.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Version=1.1
-Name=Attract-Mode
+Name=Attract-Mode Plus
 Comment=Emulator Frontend
 Exec=attractplus
 Terminal=false

--- a/util/linux/pacur/PKGBUILD
+++ b/util/linux/pacur/PKGBUILD
@@ -10,12 +10,12 @@ targets=(
 pkgname="attractplus"
 pkgver="3.2.0"
 pkgrel="1"
-pkgdesc="Attract-Mode emulator frontend"
+pkgdesc="Attract-Mode Plus emulator frontend"
 pkgdesclong=(
  "Attract-Mode Plus is a graphical frontend for command line emulators such as MAME,"
  "MESS and Nestopia. It hides the underlying operating system and is intended"
  "to be controlled with a joystick, gamepad or spin dial, making it ideal for"
- "use in arcade cabinets. Attract-Mode is open source and runs on Linux, OS X"
+ "use in arcade cabinets. Attract-Mode Plus is open source and runs on Linux, OS X"
  "and Windows."
 )
 maintainer="Andrew Mickelson <andrew@attractmode.org>"


### PR DESCRIPTION
- Replaced all "Attract-Mode" instances with "Attract-Mode Plus"
  - Except the copyright notices, which are left as-is
- Updated code comments to remove "Attract-Mode" references
- Fixes #50
- Some changes *may* have side effects:
  - `src/fe_net.cpp` - Updated the `UA_VALUE`
  - `src/fe_util_android.cpp` - Updated the `__android_log_write` tag
  - `util/android/AndroidManifest.xml` - Updated the `android:label`
  - `util/linux/pacur/PKGBUILD` - Updated the `pkgdesc`
  - `util/linux/attract-mode-plus.appdata.xml` - Updated the `name`
  - `util/linux/attract-mode-plus.desktop` - Updated the `Name`