### PR TITLE
Fix set_display in loop

### DIFF
--- a/src/fe_vm.hpp
+++ b/src/fe_vm.hpp
@@ -124,6 +124,7 @@ public:
 	void clear_handlers();
 	void clear_layout(); // override of base class clear_layout()
 
+	void update_filters_binding( Sqrat::Table &fe );
 	void update_to_new_list( int var=0, bool reset_display=false );
 
 	// runs .attract/emulators/template/setup.nut to generate default emulator


### PR DESCRIPTION
- `cb_set_display` now updates the filter binding prior to posting `Reload` command
- This allows `set_display` to access correct `fe.filters` when used in a tight loop
- Fixes #65