### PR TITLE
Fix text outline scaling

### DIFF
--- a/src/tp.cpp
+++ b/src/tp.cpp
@@ -672,6 +672,8 @@ void FeTextPrimitive::setTextScale( const sf::Vector2f &s )
 	for ( unsigned int i=0; i < m_texts.size(); i++ )
 		m_texts[i].setScale( s );
 
+	// Re-apply outline since it relies on scale
+	setOutlineThickness( getOutlineThickness() );
 	m_needs_pos_set = true;
 }
 


### PR DESCRIPTION
- Re-calculate outline thickness when scale changed
- Fixes #93
```squirrel
local flw = fe.layout.width *= 4
local flh = fe.layout.height *= 4

local font_size = flh / 6
local title1 = fe.add_text("", 0, 0, flw, flh)
local title2 = fe.add_text("", 0, font_size * 2, flw, flh)

title1.align = title2.align = Align.TopLeft
title1.outline = 3
title1.char_size = title2.char_size = font_size
title2.outline = title1.outline
title1.set_rgb(0, 0, 0)
title2.set_rgb(0, 0, 0)
title1.set_outline_rgb(255, 255, 255)
title2.set_outline_rgb(255, 255, 255)

title1.msg = title2.msg = "Sample"
```