### PR TITLE
Fix joystick moved release

### DIFF
--- a/src/fe_input.cpp
+++ b/src/fe_input.cpp
@@ -1183,7 +1183,19 @@ FeInputMap::Command FeInputMap::map_input( const sf::Event &e, const sf::IntRect
 	{
 		if ( !index.get_current_state( joy_thresh ) )
 		{
-			std::set<FeInputSingle>::iterator itr = m_tracked_keys.find( index );
+			const auto* event = e.getIf<sf::Event::JoystickMoved>();
+
+			// Special - released joystick needs to check for tracked pos/neg keys, since index will be empty
+			sf::Event pos = sf::Event::JoystickMoved{ event->joystickId, event->axis, (float)joy_thresh * 2 };
+			FeInputSingle tt( pos, mc_rect, joy_thresh, has_focus );
+			std::set<FeInputSingle>::iterator itr = m_tracked_keys.find( tt );
+
+			if ( itr == m_tracked_keys.end() ) {
+				sf::Event neg = sf::Event::JoystickMoved{ event->joystickId, event->axis, (float)joy_thresh * -2 };
+				FeInputSingle tt( neg, mc_rect, joy_thresh, has_focus );
+				itr = m_tracked_keys.find( tt );
+			}
+
 			if ( itr != m_tracked_keys.end() )
 			{
 				FeInputMap::Command c = get_command_from_tracked_keys();


### PR DESCRIPTION
- Previously upon joystick release the event would be empty, which caused the movement "key" to never clear
- When subsequent `get_command_from_tracked_keys` were called, it would match the *stuck* key
- Now it searches for the given axis corresponding pos/neg movements to release, so it can erase them and complete the command
- Fixes #68
- Fixes #203
```squirrel
fe.add_text("Mute", 0, 0, fe.layout.width, 50)
fe.add_signal_handler(this, "on_signal")
function on_signal(signal) {
    fe.log("on_signal: " + signal)
    return false
}
// - Assign toggle-mute to an analog control
// - Press that control, now the key is 'stuck'
// - Subsequent up/down controls would fire the stuck key
```