### PR TITLE
Add Custom Overlay Setting

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -1326,7 +1326,7 @@ This class is a container for overlay functionality. The instance of this class 
 
 -  `set_custom_controls( caption_text, options_listbox )`
 -  `set_custom_controls( caption_text )`
--  `set_custom_controls()` - Tells the frontend that the layout will provide custom controls for displaying overlay menus such as the exit dialog, displays menu, etc. The `caption_text` parameter is the FeText object that the frontend end should use to display the overlay caption (i.e. `"Exit Attract-Mode Plus?"`). The `options_listbox` parameter is the FeListBox object that the frontend should use to display the overlay options.
+-  `set_custom_controls()` - Customise the overlay used for Display, Filter, Tag and Exit menus. The `caption_text` parameter is the [`fe.Text`](#fetext) object used to display the caption (i.e. `"Exit Attract-Mode Plus?"`). The `options_listbox` parameter is the [`fe.Listbox`](#felistbox) object used to display the overlay options. The `Configure > General > Custom Overlay` setting must be enabled to allow custom controls.
 -  `clear_custom_controls()` - Tell the frontend that the layout will NOT do any custom control handling for overlay menus. This will result in the frontend using its built-in default menus instead for overlays.
 -  `list_dialog( options, title, default_sel, cancel_sel )`
 -  `list_dialog( options, title, default_sel )`

--- a/resources/language/en.msg
+++ b/resources/language/en.msg
@@ -44,6 +44,7 @@ Controls;Controls
 Create new tag;Create new tag
 Custom Arguments;Custom Arguments
 Custom Executable;Custom Executable
+Custom Overlay;Custom Overlay
 Default Action;Default Action
 Default Display Settings;Default Display Settings
 Delete this Display;Delete this Display
@@ -482,6 +483,7 @@ _help_misc_antialiasing;Set the anti-aliasing level
 _help_misc_check_for_updates;Configure whether Attract-Mode Plus should check for available updates on startup and display an update notification dialog when a new version is found.
 _help_misc_confirm_exit;Confirm the exiting of Attract-Mode Plus
 _help_misc_confirm_favs;Confirm the addition/removal of Favourites
+_help_misc_custom_overlay;Allow layouts to customise the overlay used for Display, Filter, Tag, and Exit menus
 _help_misc_exit_command;Command to execute when exiting the frontend [i.e. "sudo shutdown"]
 _help_misc_exit_message;Alternate message to exit the frontend [i.e. "Shut Down System"]
 _help_misc_filter_wrap_mode;Set what happens when the "Next Filter" or "Previous Filter" actions reach the end of the filter set

--- a/src/fe_config.cpp
+++ b/src/fe_config.cpp
@@ -1784,14 +1784,16 @@ void FeMiscMenu::get_options( FeConfigContext &ctx )
 	std::vector<std::string> prefix_modes = _( FeSettings::prefixDispTokens );
 	std::string prefix_mode = value_at( prefix_modes, ctx.fe_settings.get_prefix_mode() );
 	ctx.add_opt( Opt::LIST, _( "Format Game Title" ), prefix_mode, _( "_help_misc_prefix_modes" ) )->append_vlist( prefix_modes );
-	ctx.add_opt( Opt::TOGGLE, _( "Group Clones" ), ctx.fe_settings.get_info_bool( FeSettings::GroupClones ), _( "_help_misc_group_clones" ) );
-	ctx.add_opt( Opt::TOGGLE, _( "Confirm Favourites" ), ctx.fe_settings.get_info_bool( FeSettings::ConfirmFavourites ), _( "_help_misc_confirm_favs" ) );
 
 	std::vector<std::string> wrap_modes = _( FeSettings::filterWrapDispTokens );
 	std::string wrap_mode = value_at( wrap_modes, ctx.fe_settings.get_filter_wrap_mode() );
 	ctx.add_opt( Opt::LIST, _( "Filter Wrap Mode" ), wrap_mode, _( "_help_misc_filter_wrap_mode" ) )->append_vlist( wrap_modes );
 
+	ctx.add_opt( Opt::TOGGLE, _( "Custom Overlay" ), ctx.fe_settings.get_info_bool( FeSettings::CustomOverlay ), _( "_help_misc_custom_overlay" ) );
+	ctx.add_opt( Opt::TOGGLE, _( "Group Clones" ), ctx.fe_settings.get_info_bool( FeSettings::GroupClones ), _( "_help_misc_group_clones" ) );
+	ctx.add_opt( Opt::TOGGLE, _( "Confirm Favourites" ), ctx.fe_settings.get_info_bool( FeSettings::ConfirmFavourites ), _( "_help_misc_confirm_favs" ) );
 	ctx.add_opt( Opt::TOGGLE, _( "Confirm Exit" ), ctx.fe_settings.get_info_bool( FeSettings::ConfirmExit ), _( "_help_misc_confirm_exit" ) );
+
 	ctx.add_opt( Opt::EDIT, _( "Exit Command" ), ctx.fe_settings.get_info( FeSettings::ExitCommand ), _( "_help_misc_exit_command" ) );
 	ctx.add_opt( Opt::EDIT, _( "Exit Message" ), ctx.fe_settings.get_info( FeSettings::ExitMessage ), _( "_help_misc_exit_message" ) );
 
@@ -1841,9 +1843,10 @@ bool FeMiscMenu::save( FeConfigContext &ctx )
 #endif
 	ctx.fe_settings.set_info( FeSettings::HideBrackets, ctx.opt_list[i++].get_bool() );
 	ctx.fe_settings.set_info( FeSettings::PrefixMode, FeSettings::prefixTokens[ ctx.opt_list[i++].get_vindex() ] );
+	ctx.fe_settings.set_info( FeSettings::FilterWrapMode, FeSettings::filterWrapTokens[ ctx.opt_list[i++].get_vindex() ] );
+	ctx.fe_settings.set_info( FeSettings::CustomOverlay, ctx.opt_list[i++].get_bool() );
 	ctx.fe_settings.set_info( FeSettings::GroupClones, ctx.opt_list[i++].get_bool() );
 	ctx.fe_settings.set_info( FeSettings::ConfirmFavourites, ctx.opt_list[i++].get_bool() );
-	ctx.fe_settings.set_info( FeSettings::FilterWrapMode, FeSettings::filterWrapTokens[ ctx.opt_list[i++].get_vindex() ] );
 	ctx.fe_settings.set_info( FeSettings::ConfirmExit, ctx.opt_list[i++].get_bool() );
 	ctx.fe_settings.set_info( FeSettings::ExitCommand, ctx.opt_list[i++].get_value() );
 	ctx.fe_settings.set_info( FeSettings::ExitMessage, ctx.opt_list[i++].get_value() );

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -360,6 +360,7 @@ FeSettings::FeSettings( const std::string &config_path )
 	m_confirm_favs( true ),
 	m_confirm_exit( true ),
 	m_layout_preview( false ),
+	m_custom_overlay( true ),
 	m_quick_menu( false ),
 	m_track_usage( true ),
 	m_multimon( false ),
@@ -510,6 +511,7 @@ const char *FeSettings::configSettingStrings[] =
 	"anisotropic",
 	"filter_wrap_mode",
 	"layout_preview",
+	"custom_overlay",
 	"track_usage",
 	"multiple_monitors",
 	"smooth_images",
@@ -3002,6 +3004,7 @@ const std::string FeSettings::get_info( int index ) const
 	case ConfirmFavourites:
 	case ConfirmExit:
 	case LayoutPreview:
+	case CustomOverlay:
 	case QuickMenu:
 	case TrackUsage:
 	case MultiMon:
@@ -3060,6 +3063,8 @@ bool FeSettings::get_info_bool( int index ) const
 		return m_confirm_exit;
 	case LayoutPreview:
 		return m_layout_preview;
+	case CustomOverlay:
+		return m_custom_overlay;
 	case QuickMenu:
 		return m_quick_menu;
 	case TrackUsage:
@@ -3239,6 +3244,10 @@ bool FeSettings::set_info( int index, const std::string &value )
 
 	case LayoutPreview:
 		m_layout_preview = config_str_to_bool( value );
+		break;
+
+	case CustomOverlay:
+		m_custom_overlay = config_str_to_bool( value );
 		break;
 
 	case TrackUsage:

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -151,6 +151,7 @@ public:
 		Anisotropic,
 		FilterWrapMode,
 		LayoutPreview,
+		CustomOverlay,
 		TrackUsage,
 		MultiMon,
 		SmoothImages,
@@ -251,6 +252,7 @@ private:
 	bool m_confirm_favs;
 	bool m_confirm_exit;
 	bool m_layout_preview;
+	bool m_custom_overlay;
 	bool m_quick_menu;
 	bool m_track_usage;
 	bool m_multimon;

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1604,6 +1604,9 @@ int FeVM::overlay_get_list_size()
 
 void FeVM::overlay_set_custom_controls( FeText *caption, FeListBox *opts )
 {
+	if ( !m_feSettings->get_info_bool( m_feSettings->CustomOverlay ) )
+		return overlay_clear_custom_controls();
+
 	m_overlay_caption = caption;
 	m_overlay_lb = opts;
 	m_custom_overlay = true;


### PR DESCRIPTION
- Add `Custom Overlay` option to General Settings, defaults to `Yes`
- Disabling the option prevents the layout using `set_custom_controls`