### PR TITLE
Fix Splash Message Crash

### DIFF
--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1637,7 +1637,7 @@ bool FeVM::splash_message( const char *msg, const char *aux )
 
 bool FeVM::splash_message( const char *msg )
 {
-	return splash_message( msg );
+	return splash_message( msg, "" );
 }
 
 //


### PR DESCRIPTION
Fixes `fe.overlay.splash_message("crash")`