### PR TITLE
Fix TitleLetter WideString

### DIFF
--- a/src/fe_romlist.cpp
+++ b/src/fe_romlist.cpp
@@ -133,12 +133,24 @@ bool FeRomListSorter::operator()( const FeRomInfo &one_obj, const FeRomInfo &two
 	return m_reverse ? !asc : asc;
 }
 
-// Returns first character of the trimmed lowercase rom title, or '0' if none
-const char FeRomListSorter::get_first_letter( const FeRomInfo *rom )
+// Returns first character of the sort title, or an empty string if none
+// - May return a wide string, ie: pound character
+std::string FeRomListSorter::get_sort_letter( const FeRomInfo *rom )
 {
-	if ( !rom ) return '0';
+	if ( !rom ) return "";
 	const std::string &title = get_sort_title( rom->get_info( FeRomInfo::Title ) );
-	return title.empty() ? '0' : std::tolower( title.at( 0 ) );
+	if ( title.empty() ) return "";
+	return FeUtil::narrow( std::wstring( 1, FeUtil::widen( title ).at( 0 ) ) );
+}
+
+// Returns first character of the display title, or an empty string if none
+// - May return a wide string, ie: pound character
+std::string FeRomListSorter::get_display_letter( const FeRomInfo *rom )
+{
+	if ( !rom ) return "";
+	const std::string &title = get_display_title( rom->get_info( FeRomInfo::Title ) );
+	if ( title.empty() ) return "";
+	return FeUtil::narrow( std::wstring( 1, FeUtil::widen( title ).at( 0 ) ) );
 }
 
 FeRomList::FeRomList( const std::string &config_path )

--- a/src/fe_romlist.hpp
+++ b/src/fe_romlist.hpp
@@ -61,7 +61,8 @@ public:
 
 	static std::string get_display_title( const std::string &title );
 	static std::string get_sort_title( const std::string &title );
-	static const char get_first_letter( const FeRomInfo *rom );
+	static std::string get_display_letter( const FeRomInfo *rom );
+	static std::string get_sort_letter( const FeRomInfo *rom );
 
 	static void init_title_rex();
 	static void clear_title_rex();

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -2142,31 +2142,25 @@ int FeSettings::get_next_fav_offset()
 int FeSettings::get_next_letter_offset( int step )
 {
 	int filter_index = get_current_filter_index();
+	int filter_size = get_filter_size( filter_index );
 	int idx = get_rom_index( filter_index, 0 );
+	int dir = step > 0 ? 1 : -1;
 
-	const char curr_l = FeRomListSorter::get_first_letter( get_rom_absolute( filter_index, idx ) );
+	std::string curr_title = FeRomListSorter::get_sort_letter( get_rom_absolute( filter_index, idx ) );
+	const char curr_l = curr_title.empty() ? ' ' : std::tolower( curr_title.at( 0 ) );
 	bool is_alpha = std::isalpha( curr_l );
-	int retval = 0;
 
-	for ( int i=1; i < get_filter_size( filter_index ); i++ )
+	for ( int i=1; i<filter_size; i++ )
 	{
-		int t_idx;
-		if ( step > 0 )
-			t_idx = ( idx + i ) % get_filter_size( filter_index );
-		else
-			t_idx = ( i <= idx ) ? ( idx - i ) : ( get_filter_size( filter_index ) - ( i - idx ) );
+		int t_idx = ( idx + filter_size + dir * i ) % filter_size;
+		std::string test_title = FeRomListSorter::get_sort_letter( get_rom_absolute( filter_index, t_idx ) );
+		const char test_l = test_title.empty() ? ' ' : std::tolower( test_title.at( 0 ) );
 
-		const char test_l = FeRomListSorter::get_first_letter( get_rom_absolute( filter_index, t_idx ) );
-
-		if ((( is_alpha ) && ( test_l != curr_l ))
-				|| ((!is_alpha) && ( std::isalpha( test_l ) )))
-		{
-			retval = t_idx - idx;
-			break;
-		}
+		if ( is_alpha ? ( test_l != curr_l ) : std::isalpha( test_l ) )
+			return t_idx - idx;
 	}
 
-	return retval;
+	return 0;
 }
 
 void FeSettings::get_current_tags_list(
@@ -2647,9 +2641,7 @@ bool FeSettings::get_special_token_value( std::string &token, int filter_index, 
 			value = get_rom_info_absolute( filter_index, rom_index, FeRomInfo::Title );
 			return true;
 		case FeRomInfo::TitleLetter:
-			value = get_rom_info_absolute( filter_index, rom_index, FeRomInfo::Title );
-			value = FeRomListSorter::get_display_title( value );
-			if (!value.empty()) value = value.substr( 0, 1 );
+			value = FeRomListSorter::get_display_letter( get_rom_absolute( filter_index, rom_index ) );
 			return true;
 		case FeRomInfo::SortName:
 		{


### PR DESCRIPTION
- Fixed `TitleLetter` magictoken when used on WideStrings Titles
- `£6-X` now returns `£` rather than half-char `.`