### PR TITLE
Add Regex2 class

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -81,7 +81,7 @@
 
 The Attract-Mode Plus layout sets out what gets displayed to the user. Layouts consist of a `layout.nut` script file and a collection of related resources (images, other scripts, etc.) used by the script.
 
-Layouts are stored under the "layouts" subdirectory of the Attract-Mode Plus config directory. Each layout is stored in its own separate subdirectory or archive file (Attract-Mode Plus can read layouts and plugins directly from `.zip`, `.7z`, `.rar`, `.tar.gz`, `.tar.bz2` and `.tar` files).
+Layouts are stored under the "layouts" subdirectory of the Attract-Mode Plus config directory. Each layout is stored in its own separate subdirectory or archive file (Attract-Mode Plus can read layouts and plugins directly from compressed archives, see [Language Extensions](#language-extensions) for supported formats).
 
 Each layout can have one or more `layout*.nut` script files. The "Toggle Layout" command in Attract-Mode Plus allows users to cycle between each of the `layout*.nut` script files located in the layout's directory. Attract-Mode Plus remembers the last layout file toggled to for each layout and will go back to that same file the next time the layout is loaded. This allows for variations of a particular layout to be implemented and easily selected by the user (for example, a layout could provide a `layout.nut` for horizontal monitor orientations and a `layout-vert.nut` for vertical).
 
@@ -96,7 +96,7 @@ Plug-ins are similar to layouts in that they consist of at least one squirrel sc
 Attract-Mode Plus layouts are scripts written in the Squirrel programming language. Squirrel's standard `Blob`, `IO`, `Math`, `String` and `System` library functions are available for use in a script. For more information on programming in Squirrel and using its standard libraries, consult the Squirrel manuals:
 
 -  [Squirrel 3.0 Reference Manual](http://www.squirrel-lang.org/doc/squirrel3.html)
--  [Squirrel 3.0 Standard Library Manual](http://www.squirrel-lang.org/doc/sqstdlib3.html)
+-  [Squirrel 3.0 Standard Library Manual](https://web.archive.org/web/20210730072847/http://www.squirrel-lang.org/doc/sqstdlib3.html)
 
 Also check out the Introduction to Squirrel on the wiki:
 
@@ -108,10 +108,9 @@ Also check out the Introduction to Squirrel on the wiki:
 
 Attract-Mode Plus includes the following home-brewed extensions to the squirrel language and standard libraries:
 
--  A `zip_extract_archive( zipfile, filename )` function that will open a specified `zipfile` archive file and extract `filename` from it, returning the contents as a squirrel blob.
+-  A `zip_extract_archive( zipfile, filename )` function that will open a specified `zipfile` archive file and extract `filename` from it, returning the contents as a squirrel blob. Supported formats are: `.zip` `.7z` `.rar` `.tar.gz` `.tar.bz2` `.tar`
 -  A `zip_get_dir( zipfile )` function that will return an array of the filenames contained in the `zipfile` archive file.
-
-Supported archive formats are: `.zip`, `.7z`, `.rar`, `.tar.gz`, `.tar.bz2` and `.tar`.
+-  A `regexp2` class, which evaluates regular expressions using the C++ regular expression engine. Recommended over the standard `regexp` class as it contains considerable improvements.
 
 In addition to the standard `Math` library, the following methods are included:
 

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ _DEP =\
 	base64.hpp \
 	sqrat_array_wrapper.hpp \
 	sqrat_math.hpp \
+	sqrat_regexp2.hpp \
 	zip.hpp
 
 _OBJ =\
@@ -214,6 +215,7 @@ _OBJ =\
 	base64.o \
 	sqrat_array_wrapper.o \
 	sqrat_math.o \
+	sqrat_regexp2.o \
 	main.o
 
 _RES =\

--- a/src/fe_info.hpp
+++ b/src/fe_info.hpp
@@ -29,10 +29,10 @@
 #include <vector>
 #include "nowide/fstream.hpp"
 #include "cereal/cereal.hpp"
+#include <regex>
 
 extern const char *FE_STAT_FILE_EXTENSION;
 extern const char FE_TAGS_SEP;
-struct SQRex;
 
 //
 // Class for storing information regarding a specific rom
@@ -214,7 +214,8 @@ private:
 	FeRomInfo::Index m_filter_target;
 	FilterComp m_filter_comp;
 	std::string m_filter_what;
-	SQRex *m_rex;
+	std::wregex m_rex;
+	bool m_regex_compiled;
 	bool m_is_exception;
 	bool m_use_rex;
 };

--- a/src/fe_romlist.hpp
+++ b/src/fe_romlist.hpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <set>
 #include <list>
+#include <regex>
 
 #include "cereal/cereal.hpp"
 #include <cereal/types/list.hpp>
@@ -49,7 +50,8 @@ class FeRomListSorter
 private:
 	FeRomInfo::Index m_comp;
 	bool m_reverse;
-	static SQRex *m_rex;
+	static std::regex m_rex;
+	static bool m_regex_compiled;
 	static std::string get_formatted_title( const std::string &title );
 
 public:

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -841,6 +841,23 @@ std::string str_join(
 	return value.str();
 }
 
+std::string ltrim( const std::string str )
+{
+	return str.substr( str.find_first_not_of( FE_WHITESPACE ) );
+}
+
+std::string rtrim( const std::string str )
+{
+	return str.substr( 0, str.find_last_not_of( FE_WHITESPACE ) + 1 );
+}
+
+std::string trim( const std::string str )
+{
+	int begin = str.find_first_not_of( FE_WHITESPACE );
+	int end = str.find_last_not_of( FE_WHITESPACE ) + 1;
+	return str.substr( begin, end - begin );
+}
+
 std::string get_available_filename(
 			const std::string &path,
 			const std::string &base,

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -76,6 +76,11 @@ std::string str_join(
 	const std::string &delim
 );
 
+// Trim whitespace
+std::string ltrim( const std::string str );
+std::string rtrim( const std::string str );
+std::string trim( const std::string str );
+
 //
 //
 std::string name_with_brackets_stripped( const std::string &name );

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1113,6 +1113,15 @@ bool FeVM::on_new_layout()
 	SqratWrapperClass.Func( _SC("len"), &SqratArrayWrapper::len );
 	fe.Bind( _SC("SqratArrayWrapper"), SqratWrapperClass );
 
+	Sqrat::Class<Regexp2> regexp2( vm, _SC("regexp2"));
+	regexp2.Ctor<std::string>();
+	regexp2.Overload<Sqrat::Array(Regexp2::*)(std::string, int)>(_SC("capture"), &Regexp2::capture);
+	regexp2.Overload<Sqrat::Array(Regexp2::*)(std::string)>(_SC("capture"), &Regexp2::capture);
+	regexp2.Overload<Sqrat::Table(Regexp2::*)(std::string, int)>(_SC("search"), &Regexp2::search);
+	regexp2.Overload<Sqrat::Table(Regexp2::*)(std::string)>(_SC("search"), &Regexp2::search);
+	regexp2.Func(_SC("match"), &Regexp2::match);
+	RootTable( vm ).Bind(_SC("regexp2"), regexp2);
+
 	//
 	// Define functions that get exposed to Squirrel
 	//

--- a/src/fe_vm.hpp
+++ b/src/fe_vm.hpp
@@ -33,6 +33,7 @@
 
 #include <sqrat/sqratObject.h>
 #include <sqrat/sqratFunction.h>
+#include "sqrat_regexp2.hpp"
 
 class FeWindow;
 class FeOverlay;

--- a/src/sqrat_regexp2.cpp
+++ b/src/sqrat_regexp2.cpp
@@ -1,0 +1,106 @@
+/*
+ *
+ *  Attract-Mode Plus frontend
+ *  Copyright (C) 2025 Andrew Mickelson & Radek Dutkiewicz
+ *
+ *  This file is part of Attract-Mode Plus
+ *
+ *  Attract-Mode Plus is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Attract-Mode Plus is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Attract-Mode Plus.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "sqrat_regexp2.hpp"
+
+//
+// regexp2 class for squirrel
+// - strings get widened so regex can match "naïve"
+// - results get narrowed since squirrel does not use wstrings
+// - ie: "naïve".len() == 6
+//
+Regexp2::Regexp2( const std::string pattern )
+{
+	try {
+		m_regex = std::wregex( FeUtil::widen( pattern ), std::regex::ECMAScript );
+		m_compiled = true;
+	}
+	catch ( const std::regex_error& e )
+	{
+		FeLog() << "Error compiling regular expression \"" << pattern << "\": " << e.what() << std::endl;
+	}
+}
+
+Sqrat::Array Regexp2::capture( const std::string str )
+{
+	return capture( str, 0 );
+}
+
+Sqrat::Array Regexp2::capture( const std::string str, const int start )
+{
+	if ( !m_compiled )
+		return Sqrat::Object(); // null
+
+	std::wsmatch matches;
+	std::wstring text = FeUtil::widen( str.substr( start ) );
+	if ( !std::regex_search( text, matches, m_regex ) )
+		return Sqrat::Object(); // null
+
+	HSQUIRRELVM vm = Sqrat::RootTable().GetVM();
+	Sqrat::Array results( vm );
+	for (int i=0; i<matches.size(); i++)
+	{
+		int pos = matches.position(i);
+		int len = matches.length(i);
+		int begin = start + FeUtil::narrow( text.substr( 0, pos ) ).size();
+		int end = begin + FeUtil::narrow( text.substr( pos, len ) ).size();
+
+		Sqrat::Table result( vm );
+		result.SetValue( _SC("begin"), begin );
+		result.SetValue( _SC("end"), end );
+		results.Append( result );
+	}
+
+	return results;
+}
+
+Sqrat::Table Regexp2::search( const std::string str )
+{
+	return search( str, 0 );
+}
+
+Sqrat::Table Regexp2::search( const std::string str, const int start )
+{
+	if ( !m_compiled )
+		return Sqrat::Object(); // null
+
+	std::wsmatch match;
+	std::wstring text = FeUtil::widen( str.substr( start ) );
+	if ( !std::regex_search( text, match, m_regex ) )
+		return Sqrat::Object(); // null
+
+	int pos = match.position(0);
+	int len = match.length(0);
+	int begin = start + FeUtil::narrow( text.substr( 0, pos ) ).size();
+	int end = begin + FeUtil::narrow( text.substr( pos, len ) ).size();
+
+	HSQUIRRELVM vm = Sqrat::RootTable().GetVM();
+	Sqrat::Table result( vm );
+	result.SetValue( _SC("begin"), begin );
+	result.SetValue( _SC("end"), end );
+	return result;
+}
+
+bool Regexp2::match( const std::string str )
+{
+	return m_compiled && std::regex_match( FeUtil::widen( str ), m_regex );
+}

--- a/src/sqrat_regexp2.hpp
+++ b/src/sqrat_regexp2.hpp
@@ -1,0 +1,46 @@
+/*
+ *
+ *  Attract-Mode Plus frontend
+ *  Copyright (C) 2025 Andrew Mickelson & Radek Dutkiewicz
+ *
+ *  This file is part of Attract-Mode Plus
+ *
+ *  Attract-Mode Plus is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Attract-Mode Plus is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Attract-Mode Plus.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef FE_SQRAT_REGEXP2_HPP
+#define FE_SQRAT_REGEXP2_HPP
+
+#include <regex>
+#include <sqrat.h>
+#include "fe_base.hpp"
+#include "fe_util.hpp"
+
+class Regexp2
+{
+private:
+	std::wregex m_regex;
+	bool m_compiled;
+
+public:
+	Regexp2( const std::string pattern );
+	Sqrat::Array capture( const std::string str );
+	Sqrat::Array capture( const std::string str, const int start );
+	Sqrat::Table search( const std::string str );
+	Sqrat::Table search( const std::string str, const int start );
+	bool match( const std::string str );
+};
+
+#endif


### PR DESCRIPTION
- Added `regexp2` class
  - Drop-in replacement for `regexp`
  - Fixes standard `regexp` issue with greedy matches
- Replaced all API `SQRex` uses with `std::wregex`
  - Based on: https://github.com/oomek/attractplus/pull/124
  - Use wide strings to match "naïve" cases
- Updated title formatter:
  - Was `The Title (bracket)` -> `Title (bracket), The`
  - Now `The Title (bracket)` -> `Title, The (bracket)`