### PR TITLE
Add Config Save Method

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -42,6 +42,7 @@
    -  [`fe.get_input_mappings()`](#feget_input_mappings-) 🔶
    -  [`fe.get_general_config()`](#feget_general_config-) 🔶
    -  [`fe.get_config()`](#feget_config)
+   -  [`fe.set_config()`](#feset_config) 🔶
    -  [`fe.get_text()`](#feget_text)
    -  [`fe.get_url()`](#feget_url-) 🔶
    -  [`fe.log()`](#felog-) 🔶
@@ -248,7 +249,7 @@ fe.add_text( "[!copyright]", 0, 0, 400, 20 )
 
 Configuration settings can be added to a layout/plugin/screensaver/intro to provide users with customization options.
 
-Configurations are defined by a `UserConfig` class at the top of your script, where each property is an individual setting. Properties should be prefixed with an `</ attribute />` that describes how they are displayed, and their values can be retrieved using [`fe.get_config()`](#feget_config).
+Configurations are defined by a `UserConfig` class at the top of your script, where each property is an individual setting. Properties should be prefixed with an `</ attribute />` that describes how they are displayed, and their values can be retrieved using [`fe.get_config()`](#feget_config) or updated using [`fe.set_config()`](#feset_config-).
 
 ```squirrel
 class UserConfig </ help="Description" /> {
@@ -271,22 +272,30 @@ The attribute may use **one** of the following properties to define its type:
 
 -  `options` - [string] Present the user with a choice, for example: `"Yes,No"`.
 -  `is_input` - [boolean] Prompt the user to press a key.
--  `is_function` - [boolean] Call the function named by the property, for example: `func = "callback"`.
+-  `is_function` - [boolean] Call the function named by the property, see example below.
 -  `is_info` - [boolean] A readonly setting used for headings or separators.
--  (None of the above) - A text input for keyboard entry.
+-  If none of the above are used a text input for keyboard entry will be displayed.
 
 **Callback**
 
--  The function should be in the following form:
+-  The `is_function` callback should be in the following form:
 
-   ```squirrel
-   // The config parameter contains the fe.get_config() table
-   function callback( config )
-   {
-     // The returned string is displayed in the footer
-     return "Success"
-   }
-   ```
+```squirrel
+class UserConfig </ help="Description" /> {
+	</ label="String", order=1 /> val = "Default"
+	</ label="Action", order=2, is_function=true /> func = "callback"
+}
+
+// The parameter contains the fe.get_config() table
+function callback( config )
+{
+	// The config may be updated
+	config.val = ( config.val == "Default" ) ? "Changed" : "Default"
+
+	// The returned string is displayed in the help section
+	return "Success"
+}
+```
 
 ---
 
@@ -1183,6 +1192,24 @@ Get the user configured settings for this layout/plugin/screensaver/intro.
 **Notes**
 
 -  This function will _not_ return valid settings when called from a callback function registered with [`fe.add_ticks_callback()`](#feadd_ticks_callback), [`fe.add_transition_callback()`](#feadd_transition_callback) or [`fe.add_signal_handler()`](#feadd_signal_handler).
+
+---
+
+### `fe.set_config()` 🔶
+
+```squirrel
+fe.set_config( config )
+```
+
+Set the user configured settings for this layout/plugin/screensaver/intro.
+
+**Parameters**
+
+-  A table containing the [User Config](#user-config) settings.
+
+**Return Value**
+
+-  None.
 
 ---
 

--- a/src/fe_config.cpp
+++ b/src/fe_config.cpp
@@ -135,7 +135,8 @@ FeConfigContext::FeConfigContext( FeSettings &f )
 	style( SelectionList ),
 	curr_sel( -1 ),
 	default_sel( 0 ),
-	save_req( false )
+	save_req( false ),
+	update_req( false )
 {
 }
 
@@ -1899,12 +1900,18 @@ bool FeScriptConfigMenu::on_option_select(
 		if ( fep )
 			fep->set_script_id( m_script_id );
 
+		// Call function in layout is_function attribute
 		FeVM::script_run_config_function(
 				*m_configurable,
 				m_file_path,
 				m_file_name,
 				o.opaque_str,
 				ctx.help_msg );
+
+		// Force the config menu to update regardless of changes
+		// - Config changes absolutely require update
+		// - `nv` changes are harder to detect (full-table-compare), simpler to just force update
+		ctx.update_req = true;
 	}
 	return true;
 }

--- a/src/fe_config.hpp
+++ b/src/fe_config.hpp
@@ -118,6 +118,7 @@ public:
 	int curr_sel;		// index of currently selected menu option in opt_list
 	int default_sel;
 	bool save_req; 	// flag whether save() should be called on this menu
+	bool update_req;	// flag whether update_to_menu should be called, triggered when is_function changes config
 
 	FeConfigContext( FeSettings & );
 

--- a/src/fe_overlay.hpp
+++ b/src/fe_overlay.hpp
@@ -211,10 +211,6 @@ public:
 	void style_init();
 	void style_init( sf::Color theme_color );
 
-	const int is_truthy( const std::string value );
-	const int is_falsy( const std::string value );
-	const bool is_bool_list( const std::vector<std::string> &values );
-	void swap_bool_to_pill_glyphs( std::vector<std::string> &right_list, const std::vector<FeMenuOpt> &opt_list, int idx );
 };
 
 #endif

--- a/src/fe_vm.hpp
+++ b/src/fe_vm.hpp
@@ -186,7 +186,7 @@ public:
 			const std::string &script_file );
 
 	static void script_run_config_function(
-			const FeScriptConfigurable &configurable,
+			FeScriptConfigurable &configurable,
 			const std::string &script_path,
 			const std::string &script_file,
 			const std::string &func_name,
@@ -269,6 +269,7 @@ public:
 	static Sqrat::Table cb_get_input_mappings();
 	static Sqrat::Table cb_get_general_config();
 	static Sqrat::Table cb_get_config();
+	static void cb_set_config( const Sqrat::Table );
 	static void cb_signal( const char * );
 	static void cb_set_display( int, bool, bool );
 	static void cb_set_display( int, bool );


### PR DESCRIPTION
- Add `set_config()` method, allows layout to update the config
- `nv` data is now available during `is_function` config callbacks
- Config data may now be modified within an `is_function` callback
- Refactored pill-glyph handling so it occurs earlier in the chain