### PR TITLE
Update ZOrder on Transition

### DIFF
--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1512,6 +1512,12 @@ void FeVM::on_transition(
 		//
 		if (( !worklist.empty() ) && ( m_window.isOpen() ))
 		{
+			if ( m_sort_zorder_triggered )
+			{
+				sort_zorder();
+				m_sort_zorder_triggered = false;
+			}
+
 			video_tick();
 			clk.tick();
 


### PR DESCRIPTION
Issue
- A plugin draws an element with the highest `zorder` - it should be on top of everything
- The layout blocks the `StartLayout` transition, which prevents `sort_zorder` getting called
- The plugin element is not sorted to the top until the transition is un-blocked

Reproduce (master build)
- Use the `Grid` layout, which blocks on `StartLayout`
- Example plugin:
```squirrel
local r = fe.add_rectangle(0, 0, fe.layout.width, fe.layout.height)
r.set_rgb(100, 0, 0)
r.zorder = 2147483647
```

Workaround
```squirrel
fe.add_transition_callback(this, "on_transition")
function on_transition(ttype, var, ttime) {
    switch (ttype) {
        case Transition.StartLayout:
            fe.layout.redraw(); // plugin forces a redraw to call sort_zorder
            break
    }
}
```

Fix
- Call `sort_zorder` during a blocked transition
- The plugin element is now drawn on top without workarounds