### PR TITLE
Fix Reload Config Controls

### DIFF
--- a/src/fe_input.cpp
+++ b/src/fe_input.cpp
@@ -1176,6 +1176,16 @@ void FeInputMap::clear_tracked_keys()
 	m_tracked_keys.clear();
 }
 
+void FeInputMap::clear()
+{
+	m_single_map.clear();
+	m_inputs.clear();
+	m_defaults.clear();
+	m_tracked_keys.clear();
+	m_joy_config.clear();
+	m_mmove_count = 0;
+}
+
 FeInputMap::Command FeInputMap::map_input( const sf::Event &e, const sf::IntRect &mc_rect, const int joy_thresh, bool has_focus )
 {
 	FeInputSingle index( e, mc_rect, joy_thresh, has_focus );

--- a/src/fe_input.hpp
+++ b/src/fe_input.hpp
@@ -210,6 +210,8 @@ public:
 	void initialize_mappings();
 	// clear m_tracked_keys (call when focus is lost to prevent holding expired keys)
 	void clear_tracked_keys();
+	// clear all mappings and tracked keys
+	void clear();
 
 	// fix mappings when joystick connected/disconnected
 	void on_joystick_connect();

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -431,6 +431,7 @@ void FeSettings::clear()
 	m_current_config_object=NULL;
 	m_current_display = -1;
 
+	m_inputmap.clear();
 	m_displays.clear();
 	m_rl.clear_emulators();
 	m_plugins.clear();


### PR DESCRIPTION
- Fix controls not clearing before reloading

Test
- Run master
- Press `Reload Config` control a few times
- `Configure > Controls` options keeps adding to the list