### PR TITLE
Add Case Insensitive Rules

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -112,7 +112,7 @@ Attract-Mode Plus includes the following home-brewed extensions to the squirrel 
 
 -  `zip_extract_archive( zipfile, filename )` - Open a specified `zipfile` archive file and extract `filename` from it, returning the contents as a squirrel blob. Supported formats are: `.zip` `.7z` `.rar` `.tar.gz` `.tar.bz2` `.tar`
 -  `zip_get_dir( zipfile )` - Return an array of the filenames contained in the `zipfile` archive file.
--  `regexp2` - A class which evaluates regular expressions using the C++ regular expression engine. Recommended over the standard `regexp` class as it contains considerable improvements.
+-  `regexp2( pattern, flags )` - A class which evaluates regular expressions using the C++ regular expression engine. Recommended over the standard `regexp` class as it contains considerable improvements. Flags are optional, accepts `"i"` for case-insensitive matches.
 -  `join( arr, delim )` - Returns a string containing concatenated array values separated with the given delimiter.
 
 In addition to the standard `Math` library, the following methods are included:

--- a/src/fe_info.cpp
+++ b/src/fe_info.cpp
@@ -431,7 +431,7 @@ void FeRule::init()
 
 	try
 	{
-		m_rex = std::wregex( FeUtil::widen( m_filter_what ), std::regex::ECMAScript );
+		m_rex = std::wregex( FeUtil::widen( m_filter_what ), std::regex_constants::ECMAScript | std::regex_constants::icase );
 		m_regex_compiled = true;
 	}
 	catch ( const std::regex_error& e )

--- a/src/fe_romlist.cpp
+++ b/src/fe_romlist.cpp
@@ -62,7 +62,7 @@ void FeRomListSorter::init_title_rex()
 	const std::string re_mask = "^((?:Vs\\.\\s+)?(?:The\\s+)?)([^(/[]*)(.*)$";
 
 	try {
-		m_rex = std::regex( re_mask, std::regex::ECMAScript );
+		m_rex = std::regex( re_mask, std::regex_constants::ECMAScript | std::regex_constants::icase );
 		m_regex_compiled = true;
 	}
 	catch ( const std::regex_error& e )

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -489,6 +489,7 @@ namespace {
 
 		Sqrat::Class<Regexp2> regexp2( vm, _SC("regexp2"));
 		regexp2.Ctor<std::string>();
+		regexp2.Ctor<std::string, std::string>();
 		regexp2.Overload<Sqrat::Array(Regexp2::*)(std::string, int)>(_SC("capture"), &Regexp2::capture);
 		regexp2.Overload<Sqrat::Array(Regexp2::*)(std::string)>(_SC("capture"), &Regexp2::capture);
 		regexp2.Overload<Sqrat::Table(Regexp2::*)(std::string, int)>(_SC("search"), &Regexp2::search);

--- a/src/sqrat_regexp2.cpp
+++ b/src/sqrat_regexp2.cpp
@@ -28,10 +28,14 @@
 // - results get narrowed since squirrel does not use wstrings
 // - ie: "naïve".len() == 6
 //
-Regexp2::Regexp2( const std::string pattern )
+Regexp2::Regexp2( const std::string pattern, const std::string flags )
 {
 	try {
-		m_regex = std::wregex( FeUtil::widen( pattern ), std::regex::ECMAScript );
+		std::regex_constants::syntax_option_type opts = std::regex_constants::ECMAScript;
+		if ( flags.find('i') != std::string::npos )
+			opts |= std::regex_constants::icase;
+
+		m_regex = std::wregex( FeUtil::widen( pattern ), opts );
 		m_compiled = true;
 	}
 	catch ( const std::regex_error& e )
@@ -39,6 +43,8 @@ Regexp2::Regexp2( const std::string pattern )
 		FeLog() << "Error compiling regular expression \"" << pattern << "\": " << e.what() << std::endl;
 	}
 }
+
+Regexp2::Regexp2( const std::string pattern ): Regexp2::Regexp2( pattern, "" ) {}
 
 Sqrat::Array Regexp2::capture( const std::string str )
 {

--- a/src/sqrat_regexp2.hpp
+++ b/src/sqrat_regexp2.hpp
@@ -36,6 +36,7 @@ private:
 
 public:
 	Regexp2( const std::string pattern );
+	Regexp2( const std::string pattern, const std::string flags );
 	Sqrat::Array capture( const std::string str );
 	Sqrat::Array capture( const std::string str, const int start );
 	Sqrat::Table search( const std::string str );


### PR DESCRIPTION
- Filter rules now case-insensitive.
- `Vs/The` formatter now case-insensitive.
- `regexp2` now accepts second parameter `flags`, accepts `"i"` to make it case-insensitive.