### PR TITLE
Fix Version Check Crash

### DIFF
--- a/src/fe_net.cpp
+++ b/src/fe_net.cpp
@@ -328,6 +328,11 @@ FeVersionChecker::FeVersionChecker()
 
 FeVersionChecker::~FeVersionChecker()
 {
+	reset();
+}
+
+void FeVersionChecker::reset()
+{
 	m_worker.reset();
 	m_queue.reset();
 }

--- a/src/fe_net.hpp
+++ b/src/fe_net.hpp
@@ -140,6 +140,7 @@ public:
 	const std::string& get_remote_version() const { return m_remote_version; }
 	const std::string& get_current_version() const { return m_current_version; }
 	bool is_initiated() const { return m_initiated; }
+	void reset();
 };
 
 #endif

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -3070,5 +3070,5 @@ void FeVM::init_with_default_layout()
 	img->setColor( sf::Color( 255, 255, 255, 70 ) );
 
 	// Game listbox
-	FeListBox *lb = cb_add_listbox( 0, 0, flw, flh );
+	cb_add_listbox( 0, 0, flw, flh );
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1267,6 +1267,7 @@ int main(int argc, char *argv[])
 	soundsys.stop();
 
 #ifdef USE_LIBCURL
+	versionChecker.reset();
 	curl_global_cleanup();
 #endif
 

--- a/src/scraper_xml.hpp
+++ b/src/scraper_xml.hpp
@@ -86,7 +86,7 @@ private:
 	FeRomInfoListType::iterator m_itr;
 	std::map<const char *, FeRomInfoListType::iterator, FeMapComp> m_map;
 	std::vector<FeRomInfoListType::iterator> m_discarded;
-	int m_count;
+	size_t m_count;
 	int m_displays;
 	bool m_collect_data;
 	bool m_chd;


### PR DESCRIPTION
- Exiting AM during the initial language selection screen resulted in a crash
  - `curl_global_cleanup()` was having an issue with `versionChecker`
  - The segfault was at `FeNetWorker::work_process` -> `res = t.do_task( &code );`
  - Resetting the `versionChecker` prior to `curl_global_cleanup()` prevents this
- Additional housekeeping fixes (datatype, unused var) 