### PR TITLE
Update title formatter

### DIFF
--- a/src/fe_romlist.hpp
+++ b/src/fe_romlist.hpp
@@ -50,24 +50,11 @@ class FeRomListSorter
 private:
 	FeRomInfo::Index m_comp;
 	bool m_reverse;
-	static std::regex m_rex;
-	static bool m_regex_compiled;
 	static std::string get_formatted_title( const std::string &title );
 
 public:
 	FeRomListSorter( FeRomInfo::Index c = FeRomInfo::Title, bool rev=false );
-	static bool display_format;
-	static bool sort_format;
-
 	bool operator()( const FeRomInfo &obj1, const FeRomInfo &obj2 ) const;
-
-	static std::string get_display_title( const std::string &title );
-	static std::string get_sort_title( const std::string &title );
-	static std::string get_display_letter( const FeRomInfo *rom );
-	static std::string get_sort_letter( const FeRomInfo *rom );
-
-	static void init_title_rex();
-	static void clear_title_rex();
 };
 
 //

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -240,6 +240,20 @@ int icompare(
 	return std::clamp( s1 - s2, -1, 1 );
 }
 
+std::string lowercase( const std::string &value )
+{
+	std::string lower = value;
+	std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c){ return std::tolower(c); });
+	return lower;
+}
+
+std::string uppercase( const std::string &value )
+{
+	std::string upper = value;
+	std::transform(upper.begin(), upper.end(), upper.begin(), [](unsigned char c){ return std::toupper(c); });
+	return upper;
+}
+
 bool base_compare( const std::string &path,
 		const std::string &base )
 {

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -100,12 +100,17 @@ bool tail_compare(
 	const std::string &filename,
 	const char **ext_list );
 
+// Returns lowercase copy of string
+std::string lowercase( const std::string &value );
+
+// Returns uppercase copy of string
+std::string uppercase( const std::string &value );
+
 //
 // Case insensitive compare of one and two
 // - Returns -1 if one < two, 1 if one > two, 0 if equal
 //
-int icompare( const std::string &one,
-	const std::string &two );
+int icompare( const std::string &one, const std::string &two );
 
 //
 // Case insensitive check if the base filename in the given path is equal to base.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1285,8 +1285,6 @@ int main(int argc, char *argv[])
 	if ( window.isOpen() )
 		window.close();
 
-	FeRomListSorter::clear_title_rex();
-
 	soundsys.stop();
 
 #ifdef USE_LIBCURL


### PR DESCRIPTION
- Updated Display-Title formatter to remove regex method, now uses string methods
- Added display & sort title properties to rominfo
- Fixed filter rule case-insensitivity for non-regex methods

The title regex used to remove "Vs/The" is a performance drain when used for sorting.
Sorting compares everything against every other thing, and the regex was being called for both Titles *every time*.
Removing the regex makes it fast, and performing the formatting once and storing it makes it faster still.

Test:
- A branch prior to this
- Clean cache
- Settings > Format Game Title > Sort and Show
- Display > Filter > Sort > Title

40k roms go from filter time `1000ms` to `50ms`