### PR TITLE
Add Text Cursor Position

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -1866,6 +1866,7 @@ The class representing a text label in Attract-Mode Plus. Instances of this clas
 
 **Member Functions**
 
+-  `get_cursor_pos( index )` - Return the cursor `x` position relative to to the object for the given index. Does not work when `word_wrap` is `true`. Range is `[0...msg.len()]`
 -  `set_rgb( r, g, b )` - Set the red, green and blue colour values for the text. Range is `[0...255]`.
 -  `set_bg_rgb( r, g, b )` - Set the red, green and blue colour values for the text background. Range is `[0...255]`.
 -  `set_outline_rgb( r, g, b )` 🔶 - Set the red, green and blue colour values for the text outline. Range is `[0...255]`.

--- a/src/fe_text.cpp
+++ b/src/fe_text.cpp
@@ -278,6 +278,16 @@ void FeText::set_string(const char *s)
 	FePresent::script_do_update( this );
 }
 
+float FeText::get_cursor_pos( int i )
+{
+	if ( m_string.empty() || get_word_wrap() )
+		return 0;
+	int pos = std::clamp( i, 0, (int)m_string.size() );
+	std::basic_string<std::uint32_t> str;
+	sf::Utf8::toUtf32( m_string.begin(), m_string.end(), std::back_inserter( str ) );
+	return m_draw_text.setString( str, pos ).x - m_draw_text.getPosition().x;
+}
+
 int FeText::get_bgr()
 {
 	return m_draw_text.getBgColor().r;

--- a/src/fe_text.hpp
+++ b/src/fe_text.hpp
@@ -84,6 +84,8 @@ public:
 	void set_string(const char *s);
 	const char *get_string_wrapped();
 
+	float get_cursor_pos( int i );
+
 	int get_actual_width() { return m_draw_text.getActualWidth(); };
 	int get_actual_height() { return m_draw_text.getActualHeight(); };
 

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1005,9 +1005,10 @@ bool FeVM::on_new_layout()
 		.Prop(_SC("margin"), &FeText::get_margin, &FeText::set_margin )
 		.Prop(_SC("outline"), &FeText::get_outline, &FeText::set_outline )
 		.Prop(_SC("bg_outline"), &FeText::get_bg_outline, &FeText::set_bg_outline )
-		.Func( _SC("set_bg_rgb"), &FeText::set_bg_rgb )
-		.Func( _SC("set_bg_outline_rgb"), &FeText::set_bg_outline_rgb )
-		.Func( _SC("set_outline_rgb"), &FeText::set_outline_rgb )
+		.Func(_SC("get_cursor_pos"), &FeText::get_cursor_pos )
+		.Func(_SC("set_bg_rgb"), &FeText::set_bg_rgb )
+		.Func(_SC("set_bg_outline_rgb"), &FeText::set_bg_outline_rgb )
+		.Func(_SC("set_outline_rgb"), &FeText::set_outline_rgb )
 	);
 
 	fe.Bind( _SC("ListBox"),


### PR DESCRIPTION
- Add `fe.get_cursor_pos( i )` which returns x position of cursor at index (relative to text object)

```squirrel
local txt = fe.add_text("sample", 0, 0, 500, 50)
local cur = fe.add_rectangle(0, 0, 1, 50)

fe.add_ticks_callback(this, "on_tick")
function on_tick(ttime) {
    local i = (ttime / 200) % (txt.msg.len() + 1)
    cur.x = txt.x + txt.get_cursor_pos(i)
}
```
<img width="147" height="57" alt="image" src="https://github.com/user-attachments/assets/9510c96d-6f66-41fa-8666-b8033536d638" />
