### PR TITLE
Set Game Info

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -22,7 +22,8 @@
    -  [`fe.add_music()`](#feadd_music-) 🔶
    -  [`fe.add_ticks_callback()`](#feadd_ticks_callback)
    -  [`fe.add_transition_callback()`](#feadd_transition_callback)
-   -  [`fe.game_info()`](#fegame_info)
+   -  [`fe.get_game_info()`](#feget_game_info)
+   -  [`fe.set_game_info()`](#feset_game_info) 🔶
    -  [`fe.get_art()`](#feget_art)
    -  [`fe.get_input_state()`](#feget_input_state)
    -  [`fe.get_input_pos()`](#feget_input_pos)
@@ -148,6 +149,12 @@ The following _Magic Tokens_ are supported:
    -  `[DisplayType]` - The display type for the game
    -  `[AltRomname]` - The alternative rom name for the game
    -  `[AltTitle]` - The alternative title for the game
+   -  `[Extra]` - The extra information for the game
+   -  `[Buttons]` - The number of buttons used by the game
+   -  `[Series]` - The series the game belongs to
+   -  `[Language]` - The language used by the game
+   -  `[Region]` - The region the game belongs to
+   -  `[Rating]` - The age rating for the game
    -  `[Overview]` - The overview description for the game
    -  `[System]` - The first System name for the game's emulator
    -  `[SystemN]` - The last System name for the game's emulator
@@ -166,6 +173,10 @@ The following _Magic Tokens_ are supported:
    -  `[PlayedTime]` - The number of seconds the game has been played
    -  `[PlayedLast]` - The timestamp the game was last played
    -  `[PlayedAgo]` - The last played date formatted relative to now, for example: `5 Minutes Ago`
+   -  `[Score]` - The user score for the game. Range is `[0.0...5.0]`
+   -  `[ScoreStar]` - The score displayed as a number of stars, for example: `★★★`
+   -  `[ScoreStarAlt]` - The score displayed as a number of stars plus empty slots, for example: `★★★☆☆`
+   -  `[Votes]` - The total number of user votes for the game
 
 #### Custom Magic Token Functions
 
@@ -178,7 +189,7 @@ _Magic Tokens_ can also run user-defined functions in the form `[!token_function
 // Return the first word in the Manufacturer name
 function manufacturer_name()
 {
-  local m = fe.game_info( Info.Manufacturer )
+  local m = fe.get_game_info( Info.Manufacturer )
   return split( m, " " )[0]
 }
 
@@ -191,8 +202,8 @@ fe.add_image( "[!manufacturer_name].png", 0, 0 )
 // Otherwise just return the Manufacturer's name
 function copyright( index_offset, filter_offset )
 {
-  local m = fe.game_info( Info.Manufacturer, index_offset, filter_offset )
-  local y = fe.game_info( Info.Year, index_offset, filter_offset )
+  local m = fe.get_game_info( Info.Manufacturer, index_offset, filter_offset )
+  local y = fe.get_game_info( Info.Year, index_offset, filter_offset )
 
   if (( m.len() > 0 ) && ( y.len() > 0 ))
   {
@@ -670,12 +681,12 @@ Compile a GLSL shader from the given shader code for use in the layout. Also see
 
 ---
 
-### `fe.game_info()`
+### `fe.get_game_info()`
 
 ```squirrel
-fe.game_info( id )
-fe.game_info( id, index_offset )
-fe.game_info( id, index_offset, filter_offset )
+fe.get_game_info( id )
+fe.get_game_info( id, index_offset )
+fe.get_game_info( id, index_offset, filter_offset )
 ```
 
 Get information about the selected game.
@@ -699,11 +710,18 @@ Get information about the selected game.
    -  `Info.AltRomname`
    -  `Info.AltTitle`
    -  `Info.Extra`
+   -  `Info.Buttons`
+   -  `Info.Series`
+   -  `Info.Language`
+   -  `Info.Region`
+   -  `Info.Rating`
    -  `Info.Favourite`
    -  `Info.Tags`
    -  `Info.PlayedCount`
    -  `Info.PlayedTime`
    -  `Info.PlayedLast`
+   -  `Info.Score`
+   -  `Info.Votes`
    -  `Info.FileIsAvailable`
    -  `Info.System`
    -  `Info.Overview`
@@ -719,6 +737,61 @@ Get information about the selected game.
 **Notes**
 
 -  The `Info.IsPaused` attribute is `1` if the game is currently paused by the frontend, and an empty string if it is not.
+
+---
+
+### `fe.set_game_info()`
+
+```squirrel
+fe.set_game_info( id, value )
+fe.set_game_info( id, value, index_offset )
+fe.set_game_info( id, value, index_offset, filter_offset )
+```
+
+Set information about the selected game.
+
+**Parameters**
+
+-  `id` - Id of the information attribute to set. Can be one of the following values:
+   -  `Info.Name`
+   -  `Info.Title`
+   -  `Info.Emulator`
+   -  `Info.CloneOf`
+   -  `Info.Year`
+   -  `Info.Manufacturer`
+   -  `Info.Category`
+   -  `Info.Players`
+   -  `Info.Rotation`
+   -  `Info.Control`
+   -  `Info.Status`
+   -  `Info.DisplayCount`
+   -  `Info.DisplayType`
+   -  `Info.AltRomname`
+   -  `Info.AltTitle`
+   -  `Info.Extra`
+   -  `Info.Buttons`
+   -  `Info.Series`
+   -  `Info.Language`
+   -  `Info.Region`
+   -  `Info.Rating`
+   -  `Info.Favourite`
+   -  `Info.Tags`
+   -  `Info.PlayedCount`
+   -  `Info.PlayedTime`
+   -  `Info.PlayedLast`
+   -  `Info.Score`
+   -  `Info.Votes`
+-  `value` - The value to set.
+-  `index_offset` - The offset (from the current selection) of the game to update info for. i.e. `-1` = previous game, `0` = current game, `1` = next game, and so on. Default value is `0`.
+-  `filter_offset` - The offset (from the current filter) of the filter containing the selection to update info for. i.e. `-1` = previous filter, `0` = current filter. Default value is `0`.
+
+**Return Value**
+
+-  True if the value was successfully set.
+
+**Notes**
+
+-  Modifying game information does not reload the current Filter, or fire any related Transitions. If the change is expected to modify the list then `fe.signal("reload_config")` should be called afterward.
 
 ---
 
@@ -1269,6 +1342,7 @@ This class is a container for status information regarding the current display. 
 -  `search_rule` - Get/set the search rule applied to the current game list. If you set this and the resulting search finds no results, then the current game list remains displayed in its entirety. If there are results, then those results are shown instead, until search_rule is cleared or the user navigates away from the display/filter.
 -  `size` - Get the size of the current game list. If a search rule has been applied, this will be the number of matches found (if any)
 -  `clones_list` 🔶 - Returns `true` if the current list contains game clones.
+-  `tags` 🔶 - Returns array containing the available tags for the current list.
 
 ---
 
@@ -1358,11 +1432,18 @@ This class is a container for information about the available filters. Instances
    -  `Info.AltRomname`
    -  `Info.AltTitle`
    -  `Info.Extra`
+   -  `Info.Buttons`
+   -  `Info.Series`
+   -  `Info.Language`
+   -  `Info.Region`
+   -  `Info.Rating`
    -  `Info.Favourite`
    -  `Info.Tags`
    -  `Info.PlayedCount`
    -  `Info.PlayedTime`
    -  `Info.PlayedLast`
+   -  `Info.Score`
+   -  `Info.Votes`
    -  `Info.FileIsAvailable`
 -  `reverse_order` - [boolean] Will be equal to `true` if the list order has been reversed.
 -  `list_limit` - Get the value of the list limit applied to the filter game list.

--- a/Readme.md
+++ b/Readme.md
@@ -137,7 +137,7 @@ Filters are stored in `attract.cfg` and may be edited directly. Keep in mind tha
 
 - Any field from the romlist: `Name`, `Title`, `Emulator`, `CloneOf`, `Year`, `Manufacturer`, `Category`, `Players`, `Rotation`, `Control`, `Status`, `DisplayCount`, `DisplayType`, `AltRomname`, `AltTitle`, `Extra`, `Buttons`, `Series`, `Language`, `Region`, `Rating`
 - Tags: `Favourite`, `Tags`
-- Stats: `PlayedCount`, `PlayedTime`, `PlayedLast`
+- Stats: `PlayedCount`, `PlayedTime`, `PlayedLast`, `Score`, `Votes`
 - Other: `FileIsAvailable`, `Shuffle`
 
 ### Sound

--- a/src/fe_base.cpp
+++ b/src/fe_base.cpp
@@ -47,14 +47,16 @@ const char *FE_BUILD_NUMBER = FE_BUILD_D;
 
 const char *FE_WHITESPACE   = " \t\r";
 const char *FE_DIR_TOKEN    = "<DIR>";
+const float FE_SCORE_MAX    = 5.0;
 
-const char *FE_TAG_ICON         = "🏷";
-const char *FE_HEART_ICON       = "♥";
-const char *FE_HEART_ALT_ICON   = "♡";
-const char *FE_STAR_ICON        = "★";
-const char *FE_STAR_ALT_ICON    = "☆";
-const char *FE_YES_ICON         = "☒";
-const char *FE_NO_ICON          = "☐";
+const char *FE_TAG_ICON             = "🏷";
+const char *FE_HEART_ICON           = "♥";
+const char *FE_HEART_OUTLINE_ICON   = "♡";
+const char *FE_STAR_ICON            = "★";
+const char *FE_STAR_OUTLINE_ICON    = "☆";
+const char *FE_STAR_HALF_ICON       = "⯪";
+const char *FE_YES_ICON             = "☒";
+const char *FE_NO_ICON              = "☐";
 
 const char *FE_TAG_PREFIX       = "🏷 ";
 const char *FE_TAG_DELIM        = "  ";

--- a/src/fe_base.hpp
+++ b/src/fe_base.hpp
@@ -33,12 +33,14 @@ extern const char *FE_VERSION;
 
 extern const char *FE_WHITESPACE;
 extern const char *FE_DIR_TOKEN;
+extern const float FE_SCORE_MAX;
 
 extern const char *FE_TAG_ICON;
 extern const char *FE_HEART_ICON;
-extern const char *FE_HEART_ALT_ICON;
+extern const char *FE_HEART_OUTLINE_ICON;
 extern const char *FE_STAR_ICON;
-extern const char *FE_STAR_ALT_ICON;
+extern const char *FE_STAR_OUTLINE_ICON;
+extern const char *FE_STAR_HALF_ICON;
 extern const char *FE_YES_ICON;
 extern const char *FE_NO_ICON;
 

--- a/src/fe_info.hpp
+++ b/src/fe_info.hpp
@@ -125,7 +125,10 @@ public:
 		PlayedCount,
 		PlayedTime,
 		PlayedLast,
-		FileIsAvailable,
+		Score,
+		Votes,
+
+		FileIsAvailable, // this point and beyond is dynamically added
 		Shuffle,
 		LAST_INDEX
 	};
@@ -153,6 +156,8 @@ public:
 		FavouriteHeart,
 		FavouriteHeartAlt,
 		PlayedAgo,
+		ScoreStar,
+		ScoreStarAlt,
 		LAST_SPECIAL
 	};
 
@@ -188,8 +193,9 @@ public:
 	std::string as_output( void ) const;
 
 	void clear_stats();
-	void load_stats( const std::string &path );
-	void update_stats( const std::string &path, int count_incr, int played_incr );
+	bool load_stats( const std::string &path );
+	bool save_stats( const std::string &path );
+	bool update_stats( const std::string &path, int count_incr, int played_incr );
 
 	void clear(); // Clear all m_info data
 

--- a/src/fe_overlay.cpp
+++ b/src/fe_overlay.cpp
@@ -678,7 +678,7 @@ int FeOverlay::tags_dialog( int default_sel, FeInputMap::Command extra_exit )
 			if ( !tag_name.empty() )
 			{
 				tags_changed = true;
-				if ( m_feSettings.set_current_tag( tag_name, true ) )
+				if ( m_feSettings.set_tag_current( tag_name, true ) )
 					list_changed = true;
 			}
 		}
@@ -686,7 +686,7 @@ int FeOverlay::tags_dialog( int default_sel, FeInputMap::Command extra_exit )
 		{
 			// Toggle existing tag
 			tags_changed = true;
-			if ( m_feSettings.set_current_tag( tags_list[sel].first, !tags_list[sel].second ) )
+			if ( m_feSettings.set_tag_current( tags_list[sel].first, !tags_list[sel].second ) )
 				list_changed = true;
 		}
 	}

--- a/src/fe_present.cpp
+++ b/src/fe_present.cpp
@@ -964,6 +964,15 @@ bool FePresent::get_clones_list_showing() const
 		return false;
 }
 
+Sqrat::Array FePresent::get_tags_available() const
+{
+	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
+	Sqrat::Array tags( vm );
+	for ( auto tag : m_feSettings->get_tags_available() )
+		tags.Append( tag );
+	return tags;
+}
+
 int FePresent::get_selection_index() const
 {
 	return m_feSettings->get_rom_index( m_feSettings->get_current_filter_index(), 0 );

--- a/src/fe_present.hpp
+++ b/src/fe_present.hpp
@@ -211,6 +211,7 @@ protected:
 	void set_filter_index( int );
 	int get_current_filter_size() const;
 	bool get_clones_list_showing() const;
+	Sqrat::Array get_tags_available() const;
 	int get_selection_index() const;
 	int get_sort_by() const;
 	bool get_reverse_order() const;

--- a/src/fe_romlist.cpp
+++ b/src/fe_romlist.cpp
@@ -778,6 +778,16 @@ bool FeRomList::set_fav( FeRomInfo &rom, FeDisplayInfo &display, bool fav )
 }
 
 //
+// Return list of all available tags
+//
+std::vector<std::string> FeRomList::get_tags_available()
+{
+	std::vector<std::string> tags;
+	for (const auto& pair : m_tags) tags.push_back(pair.first);
+	return tags;
+}
+
+//
 // Populate given list with rom tag availability [{ tag, flagged }]
 //
 void FeRomList::get_tags_list(
@@ -792,13 +802,61 @@ void FeRomList::get_tags_list(
 		tags_list.push_back( std::pair( (*itr).first, tags.find( (*itr).first ) != tags.end() ) );
 }
 
+bool FeRomList::replace_tags( FeRomInfo &rom, FeDisplayInfo &display, const std::string &tags )
+{
+	size_t pos = 0;
+	std::string tag;
+	std::set<std::string> current_tags;
+	std::set<std::string> new_tags;
+	std::set<std::string> add_tags;
+	std::set<std::string> rem_tags;
+
+	rom.get_tags( current_tags );
+
+	while ( token_helper( tags, pos, tag ) )
+		if ( !tag.empty() )
+			new_tags.insert( tag );
+
+	for ( auto &tag : new_tags )
+		if ( !current_tags.count( tag ) )
+			add_tags.insert( tag );
+
+	for ( auto &tag : current_tags )
+		if ( !new_tags.count( tag ) )
+			rem_tags.insert( tag );
+
+	if ( !add_tags.size() && !rem_tags.size() )
+		return false;
+
+	for ( auto &tag : add_tags )
+	{
+		rom.append_tag( tag );
+		std::map<std::string, bool>::iterator itt = m_tags.find( tag );
+		if ( itt != m_tags.end() )
+			(*itt).second = true;
+		else
+			m_tags.insert( std::pair( tag, true ) );
+	}
+
+	for ( auto &tag : rem_tags )
+	{
+		rom.remove_tag( tag );
+		std::map<std::string, bool>::iterator itt = m_tags.find( tag );
+		if ( itt != m_tags.end() )
+			(*itt).second = true;
+	}
+
+	m_tags_changed = true;
+	return fix_filters( display, { FeRomInfo::Tags } );
+}
+
 //
-// Add or remove tag from rom (flag = add tag)
+// Add or remove tag from rom
 //
-bool FeRomList::set_tag( FeRomInfo &rom, FeDisplayInfo &display, const std::string &tag, bool flag )
+bool FeRomList::set_tag( FeRomInfo &rom, FeDisplayInfo &display, const std::string &tag, bool add_tag )
 {
 	bool found = rom.has_tag( tag );
-	bool changed = ( found != flag );
+	bool changed = ( found != add_tag );
 	if ( !changed ) return false;
 
 	if ( !found )
@@ -811,7 +869,7 @@ bool FeRomList::set_tag( FeRomInfo &rom, FeDisplayInfo &display, const std::stri
 	std::map<std::string, bool>::iterator itt = m_tags.find( tag );
 	if ( itt != m_tags.end() )
 		(*itt).second = true;
-	else
+	else if ( add_tag )
 		m_tags.insert( std::pair( tag, true ) );
 
 	return fix_filters( display, { FeRomInfo::Tags } );

--- a/src/fe_romlist.hpp
+++ b/src/fe_romlist.hpp
@@ -235,8 +235,10 @@ public:
 	void save_state();
 	bool set_fav( FeRomInfo &rom, FeDisplayInfo &display, bool fav );
 
+	std::vector<std::string> get_tags_available();
 	void get_tags_list( FeRomInfo &rom, std::vector< std::pair<std::string, bool> > &tags_list ) const;
 	bool set_tag( FeRomInfo &rom, FeDisplayInfo &display, const std::string &tag, bool flag );
+	bool replace_tags( FeRomInfo &rom, FeDisplayInfo &display, const std::string &tags );
 
 	int filter_size( int filter_idx ) const { return ( filter_idx < (int)m_filtered_list.size() ) ? (int)m_filtered_list[filter_idx].filter_list.size() : 0; };
 

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -295,7 +295,6 @@ private:
 		const std::string &,
 		const std::string & );
 
-	void init_display();
 	void load_state();
 	void clear();
 	void load_displays_configs();
@@ -309,10 +308,6 @@ private:
 		const char *subdir ) const;
 
 	void internal_load_language( const std::string &lang );
-
-	std::string get_played_time_display_string( int filter_index, int rom_index );
-	std::string get_played_last_display_string( int filter_index, int rom_index );
-	std::string get_played_ago_display_string( int filter_index, int rom_index );
 
 	bool internal_get_best_artwork_file(
 		const FeRomInfo &rom,
@@ -394,6 +389,7 @@ public:
 	// Returns true if the display change results in a new layout, false otherwise
 	//
 	bool set_display( int index, bool stack_previous=false );
+	void init_display();
 
 	// Return true if there are displays available to navigate back to on a "back" button press
 	//
@@ -462,6 +458,7 @@ public:
 	const std::string &get_current_display_title() const;
 	const std::string &get_rom_info( int filter_offset, int rom_offset, FeRomInfo::Index index );
 	const std::string &get_rom_info_absolute( int filter_index, int rom_index, FeRomInfo::Index index );
+	FeRomInfo *get_rom_offset( int filter_offset, int rom_offset );
 	FeRomInfo *get_rom_absolute( int filter_index, int rom_index );
 
 	int selection_delay() const { return m_selection_delay; }
@@ -559,19 +556,26 @@ public:
 
 	bool get_current_fav();
 
-	// returns true if the current list chnaged as a result of setting the tag
-	bool set_current_fav( bool );
+	// returns true if the current list changed as a result of setting the tag
+	bool set_fav_offset( bool state, int filter_offset, int rom_offset );
+	bool set_fav_absolute( bool state, int filter_index, int rom_index );
+	bool set_fav_current( bool state );
 	int get_prev_fav_offset();
 	int get_next_fav_offset();
 
 	int get_next_letter_offset( int step );
 
-	void get_current_tags_list(
-		std::vector< std::pair<std::string, bool> > &tags_list );
+	std::vector<std::string> get_tags_available();
+	void get_current_tags_list( std::vector< std::pair<std::string, bool> > &tags_list );
 
 	// returns true if the current list changed as a result of setting the tag
-	bool set_current_tag(
-			const std::string &tag, bool flag );
+	bool set_tag_offset( const std::string &tag, bool add_tag, int filter_offset, int rom_offset );
+	bool set_tag_absolute( const std::string &tag, bool add_tag, int filter_index, int rom_index );
+	bool set_tag_current( const std::string &tag, bool add_tag );
+
+	bool replace_tags_offset( const std::string &tags, int filter_offset, int rom_offset );
+	bool replace_tags_absolute( const std::string &tags, int filter_index, int rom_index );
+
 	//
 	// This function implements command-line romlist generation/imports
 	// If output_name is empty, then a non-existing filename is chosen for
@@ -613,7 +617,9 @@ public:
 	);
 
 	// Returns true if the stats update may have altered the current filters
-	bool update_stats( int count_incr, int time_incr );
+	bool update_stats_offset( int count_incr, int time_incr, int filter_offset, int rom_offset );
+	bool update_stats_absolute( int count_incr, int time_incr, int filter_index, int rom_index );
+	bool update_stats_current( int count_incr, int time_incr );
 
 	//
 	// The frontend maintains extra per game settings/extra info

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1166,6 +1166,7 @@ bool FeVM::on_new_layout()
 		.Prop( _SC("search_rule"), &FePresent::get_search_rule, &FePresent::set_search_rule )
 		.Prop( _SC("size"), &FePresent::get_current_filter_size )
 		.Prop( _SC("clones_list"), &FePresent::get_clones_list_showing )
+		.Prop( _SC("tags"), &FePresent::get_tags_available )
 
 		// The following are deprecated as of version 1.5 in favour of using the fe.filters array:
 		.Prop( _SC("filter"), &FePresent::get_filter_name )	// deprecated as of 1.5
@@ -1336,9 +1337,17 @@ bool FeVM::on_new_layout()
 #ifdef USE_LIBCURL
 	fe.Func<bool (*)(const char *, const char *)>(_SC("get_url"), &FeVM::get_url);
 #endif
-	fe.Overload<const char* (*)(int)>(_SC("game_info"), &FeVM::cb_game_info);
-	fe.Overload<const char* (*)(int, int)>(_SC("game_info"), &FeVM::cb_game_info);
-	fe.Overload<const char* (*)(int, int, int)>(_SC("game_info"), &FeVM::cb_game_info);
+	// deprecated in 3.2.0, use `get_game_info` now
+	fe.Overload<const char* (*)(int)>(_SC("game_info"), &FeVM::cb_get_game_info);
+	fe.Overload<const char* (*)(int, int)>(_SC("game_info"), &FeVM::cb_get_game_info);
+	fe.Overload<const char* (*)(int, int, int)>(_SC("game_info"), &FeVM::cb_get_game_info);
+	// ---
+	fe.Overload<const char* (*)(int)>(_SC("get_game_info"), &FeVM::cb_get_game_info);
+	fe.Overload<const char* (*)(int, int)>(_SC("get_game_info"), &FeVM::cb_get_game_info);
+	fe.Overload<const char* (*)(int, int, int)>(_SC("get_game_info"), &FeVM::cb_get_game_info);
+	fe.Overload<bool (*)(int, const char *)>(_SC("set_game_info"), &FeVM::cb_set_game_info);
+	fe.Overload<bool (*)(int, const char *, int)>(_SC("set_game_info"), &FeVM::cb_set_game_info);
+	fe.Overload<bool (*)(int, const char *, int, int)>(_SC("set_game_info"), &FeVM::cb_set_game_info);
 	fe.Overload<const char* (*)(const char *, int, int, int)>(_SC("get_art"), &FeVM::cb_get_art);
 	fe.Overload<const char* (*)(const char *, int, int)>(_SC("get_art"), &FeVM::cb_get_art);
 	fe.Overload<const char* (*)(const char *, int)>(_SC("get_art"), &FeVM::cb_get_art);
@@ -1363,6 +1372,8 @@ bool FeVM::on_new_layout()
 	fe.Overload<void (*)(int, bool, bool)>(_SC("set_display"), &FeVM::cb_set_display);
 	fe.Overload<void (*)(int, bool)>(_SC("set_display"), &FeVM::cb_set_display);
 	fe.Overload<void (*)(int)>(_SC("set_display"), &FeVM::cb_set_display);
+	fe.Overload<const char *(*)(const char *, int, int)>(_SC("get_text"), &FeVM::cb_get_text);
+	fe.Overload<const char *(*)(const char *, int)>(_SC("get_text"), &FeVM::cb_get_text);
 	fe.Overload<const char *(*)(const char *)>(_SC("get_text"), &FeVM::cb_get_text);
 
 	//
@@ -2067,6 +2078,8 @@ public:
 			fe.Func<time_t (*)(const char *)>(_SC("get_file_mtime"), &FeVM::cb_get_file_mtime);
 			// Deprecated: use fs.set_file_mtime instead
 			fe.Func<bool (*)(const char *, time_t)>(_SC("set_file_mtime"), &FeVM::cb_set_file_mtime);
+			fe.Overload<const char *(*)(const char *, int, int)>(_SC("get_text"), &FeVM::cb_get_text);
+			fe.Overload<const char *(*)(const char *, int)>(_SC("get_text"), &FeVM::cb_get_text);
 			fe.Overload<const char *(*)(const char *)>(_SC("get_text"), &FeVM::cb_get_text);
 		}
 
@@ -2995,7 +3008,7 @@ bool FeVM::cb_make_dir( const char *path )
 #endif
 }
 
-const char *FeVM::cb_game_info( int index, int offset, int filter_offset )
+const char *FeVM::cb_get_game_info( int index, int offset, int filter_offset )
 {
 	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
 	FeVM *fev = (FeVM *)sq_getforeignptr( vm );
@@ -3004,7 +3017,7 @@ const char *FeVM::cb_game_info( int index, int offset, int filter_offset )
 	{
 		// TODO: the better thing to do would be to raise a squirrel error here
 		//
-		FeLog() << "game_info(): index out of range" << std::endl;
+		FeLog() << "get_game_info(): index out of range" << std::endl;
 		return "";
 	}
 
@@ -3062,14 +3075,70 @@ const char *FeVM::cb_game_info( int index, int offset, int filter_offset )
 	return retval.c_str();
 }
 
-const char *FeVM::cb_game_info( int index, int offset )
+const char *FeVM::cb_get_game_info( int index, int offset )
 {
-	return cb_game_info( index, offset, 0 );
+	return cb_get_game_info( index, offset, 0 );
 }
 
-const char *FeVM::cb_game_info( int index )
+const char *FeVM::cb_get_game_info( int index )
 {
-	return cb_game_info( index, 0, 0 );
+	return cb_get_game_info( index, 0, 0 );
+}
+
+//
+// Updates game info using the most convenient method
+// - No transitions or updates are called after the update
+// - The user must manually signal a reload to fetch the updated info
+//
+bool FeVM::cb_set_game_info( int index, const char *value, int offset, int filter_offset )
+{
+	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
+	FeVM *fev = (FeVM *)sq_getforeignptr( vm );
+
+	if (( index >= FeRomInfo::FileIsAvailable ) || ( index < 0 ))
+	{
+		// TODO: the better thing to do would be to raise a squirrel error here
+		FeLog() << "set_game_info(): index out of range" << std::endl;
+		return false;
+	}
+
+	// Exit early if no change
+	std::string value_str = as_str( value );
+	FeRomInfo *original = fev->m_feSettings->get_rom_offset( filter_offset, offset );
+	if ( !original )
+		return false;
+
+	if ( original->get_info( (FeRomInfo::Index)index ) == value_str )
+		return true;
+
+	if ( (FeRomInfo::Index)index == FeRomInfo::Tags )
+		fev->m_feSettings->replace_tags_offset( value_str, filter_offset, offset );
+	else if ( (FeRomInfo::Index)index == FeRomInfo::Favourite )
+		fev->m_feSettings->set_fav_offset( value_str == "1" || value_str == "true", filter_offset, offset );
+	else if ( FeRomInfo::isStat( (FeRomInfo::Index)index ) )
+	{
+		original->set_info( (FeRomInfo::Index)index, value_str );
+		fev->m_feSettings->update_stats_offset( 0, 0, filter_offset, offset );
+	}
+	else
+	{
+		// updating all other rom info is SLOW
+		FeRomInfo replacement( *original );
+		replacement.set_info( (FeRomInfo::Index)index, value );
+		fev->m_feSettings->update_romlist_after_edit( *original, replacement );
+	}
+
+	return true;
+}
+
+bool FeVM::cb_set_game_info( int index, const char *value, int offset )
+{
+	return cb_set_game_info( index, value, offset, 0 );
+}
+
+bool FeVM::cb_set_game_info( int index, const char *value )
+{
+	return cb_set_game_info( index, value, 0, 0 );
 }
 
 const char *FeVM::cb_get_art( const char *art, int index_offset, int filter_offset, int art_flags )
@@ -3318,10 +3387,27 @@ void FeVM::cb_set_display( int idx )
 	cb_set_display( idx, false, true );
 }
 
+const char *FeVM::cb_get_text( const char *t, int index_offset, int filter_offset )
+{
+	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
+	FeVM *fev = (FeVM *)sq_getforeignptr( vm );
+	FeSettings *fes = fev->m_feSettings;
+
+	std::string translation = _( t );
+	fes->do_text_substitutions( translation, filter_offset, index_offset);
+	static std::string retval; // must be static to work with Squirrel
+	retval = translation; // static must be re-assigned to update
+	return retval.c_str();
+}
+
+const char *FeVM::cb_get_text( const char *t, int index_offset )
+{
+	return cb_get_text( t, index_offset, 0 );
+}
+
 const char *FeVM::cb_get_text( const char *t )
 {
-	static std::string retval = _( t );
-	return retval.c_str();
+	return cb_get_text( t, 0, 0 );
 }
 
 const char *FeVM::cb_get_clipboard()

--- a/src/fe_vm.hpp
+++ b/src/fe_vm.hpp
@@ -173,6 +173,7 @@ public:
 	void overlay_clear_custom_controls();
 	bool splash_message( const char *, const char * );
 	bool splash_message( const char * );
+	Sqrat::Array get_tags_available() const;
 
 	static void script_get_config_options(
 			FeConfigContext &ctx,
@@ -260,9 +261,12 @@ public:
 	static const char *cb_get_clipboard();
 	static void cb_set_clipboard( const char * );
 
-	static const char *cb_game_info( int,int,int);
-	static const char *cb_game_info(int,int);
-	static const char *cb_game_info(int);
+	static const char *cb_get_game_info( int, int, int );
+	static const char *cb_get_game_info( int, int );
+	static const char *cb_get_game_info( int );
+	static bool cb_set_game_info( int, const char *, int, int );
+	static bool cb_set_game_info( int, const char *, int );
+	static bool cb_set_game_info( int, const char * );
 
 	enum ArtFlags
 	{
@@ -283,6 +287,8 @@ public:
 	static void cb_set_display( int, bool, bool );
 	static void cb_set_display( int, bool );
 	static void cb_set_display( int );
+	static const char *cb_get_text( const char *, int, int );
+	static const char *cb_get_text( const char *, int );
 	static const char *cb_get_text( const char * );
 };
 

--- a/src/fe_window.cpp
+++ b/src/fe_window.cpp
@@ -690,7 +690,7 @@ bool FeWindow::run()
 		}
 	}
 
-	if ( m_fes.update_stats( 1, timer.getElapsedTime().asSeconds() ) )
+	if ( m_fes.update_stats_current( 1, timer.getElapsedTime().asSeconds() ) )
 	{
 		FePresent *fep = FePresent::script_get_fep();
 		fep->update_to( ToNewList, false );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -805,12 +805,9 @@ int main(int argc, char *argv[])
 						if ( !r )
 							r = &dummy;
 
-						feSettings.update_romlist_after_edit( *r,
-							new_entry,
-							FeSettings::InsertEntry );
-
-						// initial update shows new entry behind config
-						// dialog
+						// initial update shows new entry behind config dialog
+						feSettings.update_romlist_after_edit( *r, new_entry, FeSettings::InsertEntry );
+						feSettings.init_display();
 						feVM.update_to_new_list();
 
 						if ( feOverlay.edit_game_dialog( 0, c ) )
@@ -1008,7 +1005,7 @@ int main(int argc, char *argv[])
 						{
 							// Update without reset if the list has not been changed
 							// - This will allow layout lists to display the changed favs
-							bool list_changed = feSettings.set_current_fav( new_state );
+							bool list_changed = feSettings.set_fav_current( new_state );
 							feVM.update_to_new_list( 0, list_changed );
 							feVM.on_transition( ChangedTag, FeRomInfo::Favourite );
 						}


### PR DESCRIPTION
- Added `fe.set_game_info` which sets info back onto the game
- Renamed `fe.game_info` to `fe.get_game_info`
- Added `fe.list.tags` which returns an array of available tags
- Added `Info.Score` (float, 0.0...5.0) saved in stats
- Added `Info.Votes` (int) saved in stats
- Added *MagicTokens* for new info, with alts to show stars (NOTE: currently uses non-existent half-star)

```squirrel
fe.add_text("[Title] [ScoreStarAlt] ([Votes])", 0, 0, fe.layout.width, 50)
fe.set_game_info(Info.Score, 3)
fe.set_game_info(Info.Votes, 11)
foreach (tag in fe.list.tags) fe.log(tag)
```

*Working on a Plugin that uses these features...*