### PR TITLE
Duplicate displays handling

### DIFF
--- a/resources/language/cn.msg
+++ b/resources/language/cn.msg
@@ -287,6 +287,7 @@ Overwrite existing '$1' list?;覆盖现有的 '$1' 列表?
 Remove '$1' from Favourites?;从收藏中先锋队 '$1'?
 Rom path '$1' not found, proceed?;未找到 ROM 路径“$1”,是否继续?
 Overwrite existing '$1' mapping?;覆盖现有的“$1”映射?
+A display with this name already exists;此名称的显示已存在
 
 # --input_map_dialog --
 Press Hotkey;按下热键

--- a/resources/language/de.msg
+++ b/resources/language/de.msg
@@ -287,6 +287,7 @@ Overwrite existing '$1' list?;Existierende Romliste '$1' überschreiben?
 Remove '$1' from Favourites?;Entferne '$1' aus den Favoriten?
 Rom path '$1' not found, proceed?;ROM-Pfad '$1' nicht gefunden, fortfahren?
 Overwrite existing '$1' mapping?;Vorhandene Zuordnung '$1' überschreiben?
+A display with this name already exists;Ein Display mit diesem Namen existiert bereits
 
 # --input_map_dialog --
 Press Hotkey;betätige die Tastenkombination

--- a/resources/language/en.msg
+++ b/resources/language/en.msg
@@ -287,6 +287,7 @@ Overwrite existing '$1' list?;Overwrite existing '$1' list?
 Remove '$1' from Favourites?;Remove '$1' from Favourites?
 Rom path '$1' not found, proceed?;Rom path '$1' not found, proceed?
 Overwrite existing '$1' mapping?;Overwrite existing '$1' mapping?
+A display with this name already exists;A display with this name already exists
 
 # --input_map_dialog --
 Press Hotkey;Press Hotkey

--- a/resources/language/es.msg
+++ b/resources/language/es.msg
@@ -287,6 +287,7 @@ Overwrite existing '$1' list?;¿Desea sobreescribir la lista de roms '$1'?
 Remove '$1' from Favourites?;¿Eliminar '$1' de favoritos?
 Rom path '$1' not found, proceed?;No se encontró la ruta de la ROM '$1', ¿continuar?
 Overwrite existing '$1' mapping?;¿Sobrescribir la asignación existente de '$1'?
+A display with this name already exists;Ya existe una pantalla con este nombre
 
 # --input_map_dialog --
 Press Hotkey;Pulsar tecla de acceso rápido

--- a/resources/language/fr.msg
+++ b/resources/language/fr.msg
@@ -287,6 +287,7 @@ Overwrite existing '$1' list?;Ecraser la liste de ROM «$1» existante?
 Remove '$1' from Favourites?;Supprimer «$1» des favoris?
 Rom path '$1' not found, proceed?;Chemin ROM «$1» introuvable, continuer?
 Overwrite existing '$1' mapping?;Écraser le mappage «$1» existant?
+A display with this name already exists;Un affichage avec ce nom existe déjà
 
 # --input_map_dialog --
 Press Hotkey;Appuyer sur la touche de raccourci

--- a/resources/language/it.msg
+++ b/resources/language/it.msg
@@ -287,6 +287,7 @@ Overwrite existing '$1' list?;Sovrascrivere la lista '$1'?
 Remove '$1' from Favourites?;Elimino '$1' dai preferiti?
 Rom path '$1' not found, proceed?;Percorso ROM '$1' non trovato, procedere?
 Overwrite existing '$1' mapping?;Sovrascrivere la mappatura '$1' esistente?
+A display with this name already exists;Esiste già un display con questo nome
 
 # --input_map_dialog --
 Press Hotkey;Premi il tasto di scelta rapida

--- a/resources/language/jp.msg
+++ b/resources/language/jp.msg
@@ -287,6 +287,7 @@ Overwrite existing '$1' list?;既存のRomファイルリスト「$1」に上書
 Remove '$1' from Favourites?;お気に入りから「$1」を削除?
 Rom path '$1' not found, proceed?;ROMパス '$1' が見つかりません。続行しますか?
 Overwrite existing '$1' mapping?;既存の '$1' マッピングを上書きしますか?
+A display with this name already exists;この名前のディスプレイは既に存在します
 
 # --input_map_dialog --
 Press Hotkey;ホットキーを押す

--- a/resources/language/kr.msg
+++ b/resources/language/kr.msg
@@ -287,6 +287,7 @@ Overwrite existing '$1' list?;기존의 롬 목록 '$1' 에 덮어써도 좋습�
 Remove '$1' from Favourites?;'$1' 게임을 즐겨하는 목록에서 제거하겠습니까?
 Rom path '$1' not found, proceed?;Rom 경로 '$1'을(를) 찾을 수 없습니다. 계속하시겠습니까?
 Overwrite existing '$1' mapping?;기존 '$1' 매핑을 덮어쓰시겠습니까?
+A display with this name already exists;이 이름의 디스플레이가 이미 존재합니다
 
 # --input_map_dialog --
 Press Hotkey;단축키 누르기

--- a/resources/language/tw.msg
+++ b/resources/language/tw.msg
@@ -287,6 +287,7 @@ Overwrite existing '$1' list?;要覆寫現有的「$1」清單嗎?
 Remove '$1' from Favourites?;要從我的最愛移除「$1」嗎?
 Rom path '$1' not found, proceed?;未找到 ROM 路徑“$1”,是否繼續?
 Overwrite existing '$1' mapping?;覆蓋現有的“$1”映射?
+A display with this name already exists;此名稱的顯示已存在
 
 # --input_map_dialog --
 Press Hotkey;請按下要使用的熱鍵

--- a/src/fe_config.cpp
+++ b/src/fe_config.cpp
@@ -1149,6 +1149,18 @@ bool FeDisplayEditMenu::save( FeConfigContext &ctx )
 	FeDisplayInfo *display = get_display( ctx );
 	if ( display )
 	{
+		std::string new_name = ctx.opt_list[0].get_value();
+		std::string old_name = display->get_info( FeDisplayInfo::Name );
+
+		if ( lowercase( new_name ) != lowercase( old_name ) )
+		{
+			if ( ctx.fe_settings.check_duplicate_display_name( new_name, m_index ) )
+			{
+				ctx.basic_dialog( _( "A display with this name already exists" ), { _( "OK" ) }, 0, 0 );
+				ctx.opt_list[0].set_value( old_name );
+			}
+		}
+
 		for ( int i=0; i< FeDisplayInfo::LAST_INDEX; i++ )
 		{
 			if (( i == FeDisplayInfo::InCycle ) || ( i == FeDisplayInfo::InMenu ))
@@ -1261,6 +1273,12 @@ bool FeDisplaySelMenu::on_option_select(
 		std::string res;
 		if ( !ctx.edit_dialog( _( "Enter Display Name" ), res ) || res.empty() )
 			return false;		// if they don't enter a name then cancel
+
+		if ( ctx.fe_settings.check_duplicate_display_name( res ) )
+		{
+			ctx.basic_dialog( _( "A display with this name already exists" ), { _( "OK" ) }, 0, 0 );
+			return false;
+		}
 
 		ctx.save_req=true;
 		ctx.fe_settings.create_display( res );

--- a/src/fe_config.hpp
+++ b/src/fe_config.hpp
@@ -171,6 +171,11 @@ public:
 	virtual void tags_dialog()=0;
 
 	virtual bool check_for_cancel()=0;
+
+	virtual int basic_dialog( const std::string &msg,
+		const std::vector < std::string > &options,
+		int default_sel=0,
+		int cancel_sel=0 )=0;
 };
 
 class FeBaseConfigMenu

--- a/src/fe_overlay.cpp
+++ b/src/fe_overlay.cpp
@@ -138,6 +138,11 @@ public:
 	void update_to_menu( FeBaseConfigMenu *m );
 
 	bool check_for_cancel();
+
+	int basic_dialog( const std::string &msg,
+		const std::vector < std::string > &options,
+		int default_sel=0,
+		int cancel_sel=0 );
 };
 
 FeConfigContextImp::FeConfigContextImp( FeSettings &fes, FeOverlay &feo )
@@ -207,6 +212,14 @@ void FeConfigContextImp::update_to_menu(
 bool FeConfigContextImp::check_for_cancel()
 {
 	return m_feo.check_for_cancel();
+}
+
+int FeConfigContextImp::basic_dialog( const std::string &msg,
+	const std::vector < std::string > &options,
+	int default_sel,
+	int cancel_sel )
+{
+	return m_feo.common_basic_dialog( msg, options, default_sel, cancel_sel );
 }
 
 class FeEventLoopCtx

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -570,6 +570,18 @@ int FeSettings::process_setting( const std::string &setting,
 	if (( setting.compare( otherSettingStrings[0] ) == 0 ) // list
 		|| ( setting.compare( "list" ) == 0 )) // for backwards compatability.  As of 1.5, "list" became "display"
 	{
+		// Check for duplicate display names
+		std::string lowercase_value = lowercase( value );
+		for ( auto& display : m_displays )
+		{
+			if ( lowercase( display.get_info( FeDisplayInfo::Name ) ) == lowercase_value )
+			{
+				FeLog() << "Warning: Duplicate display name found: '" << value 
+					<< "' - skipping duplicate entry" << std::endl;
+				return 0;
+			}
+		}
+
 		m_displays.push_back( FeDisplayInfo( value ) );
 		m_current_config_object = &m_displays.back();
 	}
@@ -3620,6 +3632,20 @@ void FeSettings::delete_display( int index )
 
 	if ( m_current_display < 0 )
 		m_current_display=0;
+}
+
+bool FeSettings::check_duplicate_display_name( const std::string &name, int exclude_index ) const
+{
+	std::string lowercase_name = lowercase( name );
+	for ( int i = 0; i < (int)m_displays.size(); i++ )
+	{
+		if ( i == exclude_index )
+			continue;
+
+		if ( lowercase( m_displays[i].get_info( FeDisplayInfo::Name ) ) == lowercase_name )
+			return true;
+	}
+	return false;
 }
 
 void FeSettings::get_current_display_filter_names(

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -668,6 +668,7 @@ public:
 	FeDisplayInfo *get_display( int index );
 	FeDisplayInfo *create_display( const std::string &n );
 	void delete_display( int index );
+	bool check_duplicate_display_name( const std::string &name, int exclude_index = -1 ) const;
 
 	void create_filter( FeDisplayInfo &l, const std::string &name ) const;
 


### PR DESCRIPTION
- Prevent reading displays with duplicate display names from `displays.cfg`
- Prevent adding a display with an existing display name
- Prevent renaming a display to an existing display name