### PR TITLE
Add Startup Display Commandline Arg

### DIFF
--- a/resources/language/cn.msg
+++ b/resources/language/cn.msg
@@ -251,6 +251,7 @@ Flip;翻动
 
 # --startupDispTokens --
 Show Last Selection;显示最后的选择
+Show Random Selection;显示随机选择
 Launch Last Game;载入最后一次运行的游戏
 Show Displays Menu;界面选择器
 

--- a/resources/language/de.msg
+++ b/resources/language/de.msg
@@ -251,6 +251,7 @@ Flip;Umdrehen
 
 # --startupDispTokens --
 Show Last Selection;Zeige die letzte Auswahl
+Show Random Selection;Zufällige Auswahl anzeigen
 Launch Last Game;zuletzt gespieltes Spiel starten
 Show Displays Menu;Bildschirmmenü anzeigen
 

--- a/resources/language/en.msg
+++ b/resources/language/en.msg
@@ -251,6 +251,7 @@ Flip;Flip
 
 # --startupDispTokens --
 Show Last Selection;Show Last Selection
+Show Random Selection;Show Random Selection
 Launch Last Game;Launch Last Game
 Show Displays Menu;Show Displays Menu
 

--- a/resources/language/es.msg
+++ b/resources/language/es.msg
@@ -251,6 +251,7 @@ Flip;Invertir
 
 # --startupDispTokens --
 Show Last Selection;Mostrar última selección
+Show Random Selection;Mostrar selección aleatoria
 Launch Last Game;Iniciar último juego
 Show Displays Menu;Mostrar menú de pantallas
 

--- a/resources/language/fr.msg
+++ b/resources/language/fr.msg
@@ -251,6 +251,7 @@ Flip;Retourné
 
 # --startupDispTokens --
 Show Last Selection;Afficher la dernière sélection
+Show Random Selection;Afficher la sélection aléatoire
 Launch Last Game;Lancer le dernier jeu
 Show Displays Menu;Afficher le menu des écrans
 

--- a/resources/language/it.msg
+++ b/resources/language/it.msg
@@ -251,6 +251,7 @@ Flip;Inverti
 
 # --startupDispTokens --
 Show Last Selection;Mostra l'ultima selezione
+Show Random Selection;Mostra selezione casuale
 Launch Last Game;Esegui l'ultimo gioco
 Show Displays Menu;Mostra menù dei display
 

--- a/resources/language/jp.msg
+++ b/resources/language/jp.msg
@@ -251,6 +251,7 @@ Flip;180°
 
 # --startupDispTokens --
 Show Last Selection;前回の選択を表示
+Show Random Selection;ランダム選択を表示
 Launch Last Game;最後のゲームを起動
 Show Displays Menu;ディスプレイメニューを表示
 

--- a/resources/language/kr.msg
+++ b/resources/language/kr.msg
@@ -251,6 +251,7 @@ Flip;180도
 
 # --startupDispTokens --
 Show Last Selection;마지막 메뉴 표시
+Show Random Selection;무작위 선택 표시
 Launch Last Game;마지막 게임 실행
 Show Displays Menu;목록 관리 메뉴 표시
 

--- a/resources/language/tw.msg
+++ b/resources/language/tw.msg
@@ -251,6 +251,7 @@ Flip;翻轉
 
 # --startupDispTokens --
 Show Last Selection;顯示最後選擇的項目
+Show Random Selection;顯示隨機選擇
 Launch Last Game;最後執行的遊戲
 Show Displays Menu;顯示主選單
 

--- a/src/fe_cmdline.cpp
+++ b/src/fe_cmdline.cpp
@@ -46,6 +46,8 @@ void write_option( std::string args, std::string help = "" )
 void process_args( int argc, char *argv[],
 			std::string &config_path,
 			bool &process_console,
+			std::string &startup_display,
+			std::string &startup_filter,
 			std::string &log_file,
 			FeLogLevel &log_level,
 			bool &window_topmost,
@@ -291,6 +293,18 @@ void process_args( int argc, char *argv[],
 			window_topmost = true;
 			next_arg++;
 		}
+		else if (( strcmp( argv[next_arg], "-d" ) == 0 )
+				|| ( strcmp( argv[next_arg], "--display" ) == 0 ))
+		{
+			next_arg++;
+			startup_display = argv[next_arg];
+			next_arg++;
+			if ( next_arg < argc && argv[next_arg][0] != '-' )
+			{
+				startup_filter = argv[next_arg];
+				next_arg++;
+			}
+		}
 		else if (( strcmp( argv[next_arg], "-w" ) == 0 )
 				|| ( strcmp( argv[next_arg], "--window" ) == 0 ))
 		{
@@ -352,6 +366,7 @@ void process_args( int argc, char *argv[],
 			write_option( "-n, --console", "Enable script console" );
 #endif
 			write_option( "-c, --config <dir>", "Set the directory containing attract.cfg" );
+			write_option( "-d, --display <display> [filter]", "Show the given Display and Filter on startup" );
 			write_option( "-w, --window <x> <y> <w> <h>", "Set the position and size for window modes" );
 			write_option( "-t, --topmost", "Keep the window always on top" );
 			write_option( "-v, --version", "Show version information" );

--- a/src/fe_romlist.cpp
+++ b/src/fe_romlist.cpp
@@ -641,6 +641,11 @@ void FeRomList::create_filters(
 		FeCache::save_filter( display, m_filtered_list[i], i );
 	}
 
+	// Keep the rom_index for each filter in-range by wrapping it
+	// - This feature is used by show_random_selection which set a random index before knowing the list size
+	for ( int i=0; i<filters_count; i++ )
+		display.set_rom_index( i, display.get_rom_index( i ) % m_filtered_list[i].filter_list.size() );
+
 	FeLog() << " - Loaded filters in "
 		<< load_timer.getElapsedTime().asMilliseconds() << " ms ("
 		<< filters_count << " filters, "

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -114,7 +114,7 @@ public:
 	static const char *filterWrapTokens[];
 	static const char *filterWrapDispTokens[];
 
-	enum StartupModeType { ShowLastSelection=0, LaunchLastGame, ShowDisplaysMenu };
+	enum StartupModeType { ShowLastSelection=0, ShowRandomSelection, ShowDisplaysMenu, LaunchLastGame };
 	static const char *startupTokens[];
 	static const char *startupDispTokens[];
 
@@ -404,6 +404,7 @@ public:
 	bool navigate_display( int step, bool wrap_mode=false );
 	bool navigate_filter( int step );
 
+	int get_filter_index_from_name( const std::string &name ) const;
 	int get_current_filter_index() const;
 	const std::string &get_filter_name( int filter_index );
 	void get_current_display_filter_names( std::vector<std::string> &list ) const;


### PR DESCRIPTION
- Added Startup Mode: `Show Random Selection`
  - Selects a random Display, Filter and Rom
- Added `-d --display <display> [filter]` command-line arg
  - Starts AM in `show_last_selection` mode with the given display, and optionally filter
  - Accepts case-insensitive names, or indexes

```cmd
attractplus.exe -d Mame
attractplus.exe -d MAME
attractplus.exe -d Mame Favourites
attractplus.exe -d Mame "Name with spaces"
attractplus.exe -d 0 1
```