### PR TITLE
OSX Clipboard Fix

### DIFF
--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -1284,6 +1284,11 @@ bool FeSettings::get_current_state( FeInputMap::Command c )
 	return m_inputmap.get_current_state( c, m_joy_thresh );
 }
 
+bool FeSettings::get_key_state( std::string key )
+{
+	return FeInputMapEntry( key ).get_current_state( m_joy_thresh );
+}
+
 void FeSettings::init_mouse_capture( sf::RenderWindow *window )
 {
 	sf::Vector2i size = sf::Vector2i( window->getSize() );

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -362,6 +362,7 @@ public:
 	void set_default_command( FeInputMap::Command c, FeInputMap::Command v );
 
 	bool get_current_state( FeInputMap::Command c );
+	bool get_key_state( std::string key );
 	void get_input_mappings( std::vector < FeMapping > &l ) const { m_inputmap.get_mappings( l ); };
 	void set_input_mapping( FeMapping &m ) { m_inputmap.set_mapping( m ); };
 

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -28,6 +28,7 @@
 #include <set>
 #include <SFML/Config.hpp>
 #include <SFML/Graphics.hpp>
+#include <SFML/Window/Clipboard.hpp>
 #include "nowide/fstream.hpp"
 
 #ifdef FE_DEBUG

--- a/src/fe_util_osx.hpp
+++ b/src/fe_util_osx.hpp
@@ -33,16 +33,6 @@
 void osx_hide_menu_bar();
 
 //
-// Get a string from the OS X clipboard.
-//
-std::string osx_clipboard_get_content();
-
-//
-// Set a string to the OS X clipboard.
-//
-void osx_clipboard_set_content( const std::string & );
-
-//
 // Put the focus on the frontend.
 //
 void osx_take_focus();

--- a/src/fe_util_osx.mm
+++ b/src/fe_util_osx.mm
@@ -49,25 +49,6 @@ void osx_hide_menu_bar()
 	[NSMenu setMenuBarVisible:NO];
 }
 
-std::string osx_clipboard_get_content()
-{
-	cocoa_ar_pool_class pool;
-
-	NSPasteboard* pboard = [NSPasteboard generalPasteboard];
-	NSString* nstext = [pboard stringForType:NSPasteboardTypeString];
-	return std::string( [nstext UTF8String] );
-}
-
-void osx_clipboard_set_content( const std::string &value )
-{
-	cocoa_ar_pool_class pool;
-
-	NSString *nstext = [NSString stringWithCString:value.c_str() encoding:NSUTF8StringEncoding];
-	NSPasteboard* pboard = [NSPasteboard generalPasteboard];
-	[pboard clearContents];
-	[pboard setString:nstext forType:NSPasteboardTypeString];
-}
-
 void osx_take_focus()
 {
 	[NSApp activateIgnoringOtherApps:YES];
@@ -75,6 +56,6 @@ void osx_take_focus()
 
 bool osx_get_capslock()
 {
-	CGEventFlags flags = CGEventSourceFlagsState(kCGEventSourceStatePrivate);
-	return ((flags & kCGEventFlagMaskAlphaShift) == kCGEventFlagMaskAlphaShift);
+	NSUInteger flags = [NSEvent modifierFlags];
+	return ( flags & NSAlphaShiftKeyMask );
 }

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -2728,22 +2728,29 @@ bool FeVM::cb_get_input_state( const char *input )
 	else if ( strcmp( input, "Shift" ) == 0 )
 	{
 		// Returns true if either shift active
-		if ( FeInputMapEntry( "LShift" ).get_current_state( fev->m_feSettings->get_joy_thresh() ) ) return true;
-		if ( FeInputMapEntry( "RShift" ).get_current_state( fev->m_feSettings->get_joy_thresh() ) ) return true;
+		if ( fev->m_feSettings->get_key_state( "LShift" ) ) return true;
+		if ( fev->m_feSettings->get_key_state( "RShift" ) ) return true;
 		return false;
 	}
 	else if ( strcmp( input, "Control" ) == 0 )
 	{
 		// Returns true if either control active
-		if ( FeInputMapEntry( "LControl" ).get_current_state( fev->m_feSettings->get_joy_thresh() ) ) return true;
-		if ( FeInputMapEntry( "RControl" ).get_current_state( fev->m_feSettings->get_joy_thresh() ) ) return true;
+		if ( fev->m_feSettings->get_key_state( "LControl" ) ) return true;
+		if ( fev->m_feSettings->get_key_state( "RControl" ) ) return true;
 		return false;
 	}
 	else if ( strcmp( input, "Alt" ) == 0 )
 	{
 		// Returns true if either alt active
-		if ( FeInputMapEntry( "LAlt" ).get_current_state( fev->m_feSettings->get_joy_thresh() ) ) return true;
-		if ( FeInputMapEntry( "RAlt" ).get_current_state( fev->m_feSettings->get_joy_thresh() ) ) return true;
+		if ( fev->m_feSettings->get_key_state( "LAlt" ) ) return true;
+		if ( fev->m_feSettings->get_key_state( "RAlt" ) ) return true;
+		return false;
+	}
+	else if ( strcmp( input, "System" ) == 0 )
+	{
+		// Returns true if either system active
+		if ( fev->m_feSettings->get_key_state( "LSystem" ) ) return true;
+		if ( fev->m_feSettings->get_key_state( "RSystem" ) ) return true;
 		return false;
 	}
 
@@ -3411,7 +3418,9 @@ const char *FeVM::cb_get_text( const char *t )
 
 const char *FeVM::cb_get_clipboard()
 {
-	return clipboard_get_content().c_str();
+	static std::string retval;
+	retval = clipboard_get_content();
+	return retval.c_str();
 }
 
 void FeVM::cb_set_clipboard( const char *value )


### PR DESCRIPTION
- Fixes issue with `osx_get_capslock` crash on OSX

Calling our resident Mac operatives @estefan3112 @zpaolo11x for assistance testing this
- Use `SearchPlus` from my bundle on Discord
- Ideally AM *should not crash* when the Search dialog is displayed (that's a good first step)
- Plugin Options: Keyboard: Yes (now you can type into the dialog)
- `CapsLock` should work as expected (ie: on/off = upper/lower text entry)
- `Ctrl+C` should copy all search text
- `Ctrl+V` should paste into search text