### PR TITLE
Update Mouse Inputs

### DIFF
--- a/src/fe_input.hpp
+++ b/src/fe_input.hpp
@@ -108,6 +108,21 @@ private:
 	int m_code;
 };
 
+class FeInputMouse
+{
+private:
+	static sf::Vector2i m_pos_last;
+	static sf::Vector2i m_pos_delta;
+	static int m_wheel_delta;
+
+public:
+	static void clear();
+	static void set_wheel_delta( int delta );
+	static int get_wheel_delta();
+	static void set_pos_delta( sf::Vector2i p );
+	static sf::Vector2i get_pos_delta();
+};
+
 class FeInputMapEntry;
 
 class FeInputMap : public FeBaseConfigurable

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -380,6 +380,7 @@ int main(int argc, char *argv[])
 			redraw=true;
 		}
 
+		FeInputMouse::clear();
 		FeInputMap::Command c;
 		std::optional<sf::Event> ev;
 		bool from_ui;


### PR DESCRIPTION
- Fix mouse wheel delta to prevent it clearing on first read
- Added state for mouse movement and wheel deltas, can now be used with `fe.get_input_state()`
- Test [Layout](https://github.com/Chadnaut/Attract-Mode-Experiments/blob/master/layouts/Experiment.Keyboard/layout.nut)

Behaves similar to Joystick axis, in that it has both numeric positional value as well as a boolean on/off state.

<img width="200" height="200" alt="image" src="https://github.com/user-attachments/assets/0f247225-0033-456f-8184-a84bd1cd12af" />