### PR TITLE
Fix Empty Launch Crash

### DIFF
--- a/src/fe_romlist.cpp
+++ b/src/fe_romlist.cpp
@@ -581,6 +581,9 @@ void FeRomList::get_clone_group(
 	std::vector<FeRomInfo*> &group
 )
 {
+	if ( idx >= filter_size( filter_idx ) )
+		return;
+
 	FeRomInfo &rom = lookup( filter_idx, idx );
 
 	// Get the clone name


### PR DESCRIPTION
- Fix crash when attempting to launch game from an empty list

Occurs during first run if user presses `Select` instead of `Tab` to configure.