### PR TITLE
Fix First Key Debounce

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1247,6 +1247,7 @@ int main(int argc, char *argv[])
 		if ( feSettings.get_present_state() == FeSettings::Layout_Showing && ( feSettings.displays_count() < 1 ) )
 		{
 			feOverlay.splash_logo( _( "Press TAB to Configure" ) );
+			feVM.tick();
 			continue;
 		}
 


### PR DESCRIPTION
- Fix issue where the very first keypress is ignored because it fails the debounce test when `m_last_ui_cmd` in unset

Test:
- Launch (dont touch any inputs/mouse/etc)
- When loaded press TAB to enter config menu
- In current master the first keypress will be ignored