### PR TITLE
Fix AudioFX issues

### DIFF
--- a/src/fe_audio_fx.cpp
+++ b/src/fe_audio_fx.cpp
@@ -673,6 +673,11 @@ void FeAudioVisualiser::update_fall() const
 		apply_vu_fall( m_fft_left_in[i], m_fft_left_out[i], fft_fall_amount );
 		apply_vu_fall( m_fft_right_in[i], m_fft_right_out[i], fft_fall_amount );
 	}
+
+	// Reset FFT input values so they can fall properly when no audio is present
+	m_fft_mono_in.assign( m_fft_bands, 0.0f );
+	m_fft_left_in.assign( m_fft_bands, 0.0f );
+	m_fft_right_in.assign( m_fft_bands, 0.0f );
 }
 
 FeAudioNormaliser::FeAudioNormaliser()

--- a/src/fe_image.hpp
+++ b/src/fe_image.hpp
@@ -29,6 +29,7 @@
 #include "fe_presentable.hpp"
 #include "fe_blend.hpp"
 #include "sqrat_array_wrapper.hpp"
+#include "fe_audio_fx.hpp"
 
 class FeSettings;
 class FeMedia;
@@ -192,6 +193,13 @@ public:
 	void set_fft_bands( int );
 	int get_fft_bands() const;
 
+	float get_vu_mono() const;
+	float get_vu_left() const;
+	float get_vu_right() const;
+	const std::vector<float> *get_fft_mono_ptr() const;
+	const std::vector<float> *get_fft_left_ptr() const;
+	const std::vector<float> *get_fft_right_ptr() const;
+
 	float get_sample_aspect_ratio() const;
 
 	FeMedia *get_media() const;
@@ -235,6 +243,7 @@ private:
 	float m_pan;
 	int m_fft_bands;
 	FeImageLoaderEntry *m_entry;
+	FeAudioEffectsManager m_audio_effects;
 };
 
 class FeSurfaceTextureContainer : public FeBaseTextureContainer, public FePresentableParent

--- a/src/fe_music.cpp
+++ b/src/fe_music.cpp
@@ -70,21 +70,7 @@ FeMusic::FeMusic( bool loop, FeSoundInfo::SoundType st )
 	                                    float *output_frames, unsigned int &output_frame_count,
 	                                    unsigned int frame_channel_count )
 	{
-		if ( input_frames && input_frame_count > 0 )
-		{
-			m_audio_effects.process_all( input_frames, output_frames, input_frame_count, frame_channel_count );
-		}
-		else
-		{
-			m_audio_effects.reset_all();
-
-			if ( input_frames && output_frames && input_frame_count > 0 )
-			{
-				const unsigned int total_samples = input_frame_count * frame_channel_count;
-				std::memcpy( output_frames, input_frames, total_samples * sizeof(float) );
-			}
-		}
-
+		m_audio_effects.process_all( input_frames, output_frames, input_frame_count, frame_channel_count );
 		output_frame_count = input_frame_count;
 	});
 }
@@ -115,9 +101,7 @@ void FeMusic::load( const std::string &fn )
 	}
 	m_file_name = fn;
 
-	auto* normaliser = m_audio_effects.get_effect<FeAudioNormaliser>();
-	if ( normaliser )
-		normaliser->reset();
+	m_audio_effects.reset_all();
 }
 
 void FeMusic::set_file_name( const char *n )

--- a/src/media.hpp
+++ b/src/media.hpp
@@ -52,7 +52,7 @@ public:
 		AudioVideo=0x03
 	};
 
-	FeMedia( Type t );
+	FeMedia( Type t, FeAudioEffectsManager &effects_manager );
 	~FeMedia();
 
 	bool open( const std::string &archive,
@@ -126,7 +126,7 @@ private:
 	std::mutex m_callback_mutex;
 	std::mutex m_closing_mutex;
 
-	FeAudioEffectsManager m_audio_effects;
+	FeAudioEffectsManager &m_audio_effects;
 	void setup_effect_processor();
 
 	FeMedia( const FeMedia & );


### PR DESCRIPTION
- Fix fe.ambient_sound.playing
- Move AudioFX from FeMedia to FeImage
- Fixes vu and fft resets on changing media
- Fix FFT freezes for videos with no audio track
- Simplify VU and FFT getters
- Remove duplicate update_all(). Add missing reset_all()
- Remove redundant normaliser->reset() calls
- Remove redundant code in audiofx callbacks