### PR TITLE
Fix segfaults caused by AudioFX chain in videos

### DIFF
--- a/src/media.cpp
+++ b/src/media.cpp
@@ -946,7 +946,6 @@ FeMedia::FeMedia( Type t, FeAudioEffectsManager &effects_manager )
 
 FeMedia::~FeMedia()
 {
-	m_alive.store( false, std::memory_order_release );
 	close();
 
 	delete m_imp;
@@ -999,6 +998,8 @@ void FeMedia::play()
 
 void FeMedia::signal_stop()
 {
+	m_alive.store( false, std::memory_order_release );
+
 	if ( m_audio )
 		sf::SoundStream::stop();
 


### PR DESCRIPTION
Move m_alive = false to signal_stop()
Regression caused by commits:
2d0d40803620ca98c827fb97a4b586292d2537ca
and
7a8b1a58798082ac42a41fdfdfa00449a0de3b03