### PR TITLE
Revert Squirrel Regex

### DIFF
--- a/extlibs/squirrel/sqstdlib/sqstdrex.cpp
+++ b/extlibs/squirrel/sqstdlib/sqstdrex.cpp
@@ -52,7 +52,6 @@ typedef int SQRexNodeType;
 
 typedef struct tagSQRexNode{
 	SQRexNodeType type;
-	SQRexNodeType extra; // AM+
 	SQInteger left;
 	SQInteger right;
 	SQInteger next;
@@ -80,7 +79,6 @@ static SQInteger sqstd_rex_newnode(SQRex *exp, SQRexNodeType type)
 {
 	SQRexNode n;
 	n.type = type;
-	n.extra = OP_EOL; // AM+
 	n.next = n.right = n.left = -1;
 	if(type == OP_EXPR)
 		n.right = exp->_nsubexpr++;
@@ -162,15 +160,7 @@ static SQInteger sqstd_rex_charnode(SQRex *exp,SQBool isclass)
 	}
 	else if(!scisprint(*exp->_p)) {
 		
-		// sqstd_rex_error(exp,_SC("letter expected"));
-
-		// ----- AM+
-		// if non-printable assume Unicode and add next char to the node
-		t = *exp->_p; exp->_p++;
-		SQInteger n = sqstd_rex_newnode(exp,t);
-		exp->_nodes[n].extra = *exp->_p; exp->_p++;
-		return n;
-		// -----
+		sqstd_rex_error(exp,_SC("letter expected"));
 	}
 	t = *exp->_p; exp->_p++; 
 	return sqstd_rex_newnode(exp,t);
@@ -367,11 +357,8 @@ static SQBool sqstd_rex_matchcclass(SQInteger cclass,SQChar c)
 	return SQFalse; /*cannot happen*/
 }
 
-// static SQBool sqstd_rex_matchclass(SQRex* exp,SQRexNode *node,SQChar c)
-static SQBool sqstd_rex_matchclass(SQRex* exp,SQRexNode *node,const SQChar *cp) // AM+
+static SQBool sqstd_rex_matchclass(SQRex* exp,SQRexNode *node,SQChar c)
 {
-	SQChar c = *cp; // AM+
-	SQChar d = *(cp+1); // AM+
 	do {
 		switch(node->type) {
 			case OP_RANGE:
@@ -381,8 +368,7 @@ static SQBool sqstd_rex_matchclass(SQRex* exp,SQRexNode *node,const SQChar *cp) 
 				if(sqstd_rex_matchcclass(node->left,c)) return SQTrue;
 				break;
 			default:
-				// if(c == node->type)return SQTrue;
-				if((c == node->type) && ((node->extra == OP_EOL) || (d == node->extra))) return SQTrue; // AM+
+				if(c == node->type)return SQTrue;
 		}
 	} while((node->next != -1) && (node = &exp->_nodes[node->next]));
 	return SQFalse;
@@ -515,9 +501,7 @@ static const SQChar *sqstd_rex_matchnode(SQRex* exp,SQRexNode *node,const SQChar
 		return str;
 	case OP_NCLASS:
 	case OP_CLASS:
-		// if(sqstd_rex_matchclass(exp,&exp->_nodes[node->left],*str)?(type == OP_CLASS?SQTrue:SQFalse):(type == OP_NCLASS?SQTrue:SQFalse)) {
-		if(sqstd_rex_matchclass(exp,&exp->_nodes[node->left],str)?(type == OP_CLASS?SQTrue:SQFalse):(type == OP_NCLASS?SQTrue:SQFalse)) { // AM+
-			if(!scisprint(*str)) str++; // AM+
+		if(sqstd_rex_matchclass(exp,&exp->_nodes[node->left],*str)?(type == OP_CLASS?SQTrue:SQFalse):(type == OP_NCLASS?SQTrue:SQFalse)) {
 			str++;
 			return str;
 		}
@@ -531,11 +515,6 @@ static const SQChar *sqstd_rex_matchnode(SQRex* exp,SQRexNode *node,const SQChar
 	default: /* char */
 		if(*str != node->type) return NULL;
 		str++;
-		if (node->extra != OP_EOL) // AM+
-		{
-			if(*str != node->extra) return NULL;
-			str++;
-		}
 		return str;
 	}
 	return NULL;


### PR DESCRIPTION
Not needed since `regex2` was added.

```nut
local line = "	romlist"
local pattern = @"^[\s\t]*(.+)"

local re = regexp(pattern)
local match = re.capture(line);
fe.log("regex1: " + line.slice(match[1].begin, match[1].end)) // with AM hack = "omlist", reverted = "romlist"

local re = regexp2(pattern)
local match = re.capture(line);
fe.log("regex2: " + line.slice(match[1].begin, match[1].end)) // regex2 = "romlist"
```