### PR TITLE
Add Sort Order

### DIFF
--- a/Layouts.md
+++ b/Layouts.md
@@ -1509,7 +1509,7 @@ This class is a container for information about the available filters. Instances
    -  `Info.Score`
    -  `Info.Votes`
    -  `Info.FileIsAvailable`
--  `reverse_order` - [boolean] Will be equal to `true` if the list order has been reversed.
+-  `ascending_order` - [boolean] Will be `true` if the list is sorted in ascending order, `false` if descending.
 -  `list_limit` - Get the value of the list limit applied to the filter game list.
 
 ---

--- a/resources/language/cn.msg
+++ b/resources/language/cn.msg
@@ -100,7 +100,9 @@ Overview;概览
 Plugins;插件
 Power Saving;省电模式
 Remove Input;移除-设置按键
-Reverse Order;反向播放
+Sort Order;排序
+Ascending;上升
+Descending;下降
 Rule;规则
 Scrape Artwork;搜刮插图
 Scrape Fanart;搜刮玩家自制 (Fanart)
@@ -476,7 +478,7 @@ _help_filter_delete;删除此筛选器
 _help_filter_exception;配置此过滤器例外。如果游戏符合例外, 则会将其列在过滤器中。规则和例外将按列出的顺序应用
 _help_filter_list_limit;如果您希望限制排序列表的大小, 请将其设置为非零值。前 X 个条目使用正值(例如, “10”表示前 10 个条目), 后 X 个条目使用负值(例如, “-25”表示后 25 个条目), 或使用“0”表示无限制。
 _help_filter_name;此过滤器的名称
-_help_filter_reverse_order;反转已排序的收藏集/ROM 列表的顺序。默认排序方式为：信息按字母“A”到“Z”排列, 统计数据按“从大到小”排列, 或者选择“不排序”时按源列表顺序排列。
+_help_filter_sort_order;收藏/ROM列表的排序方式。升序排列，信息按字母顺序“A”到字母“Z”排列，统计数据按文件大小“从小到大”排列，不排序则按文件来源顺序排列。降序排列与上述顺序相反。
 _help_filter_rule;配置此筛选规则。游戏必须符合所有筛选规则(或一个例外)才能被列入筛选器。
 _help_filter_sort_by;您希望用于对游戏合集/ROM列表进行排序的游戏信息属性。设置为“No Sort”可保留源合集/ROM列表的顺序。
 _help_game_custom_args;设置此项可覆盖此游戏的默认命令行参数。如果希望不使用任何参数进行覆盖, 请将其设置为[nothing]。以下参数将被相应替换：[name]、[romext]、[rompath]、[emulator]、[romfilename]、[system]、[systemn]。

--- a/resources/language/de.msg
+++ b/resources/language/de.msg
@@ -100,7 +100,9 @@ Overview;Übersicht
 Plugins;Plugins
 Power Saving;Energiesparmodus
 Remove Input;Steuerung löschen
-Reverse Order;Reihenfolge umkehren
+Sort Order;Sortierreihenfolge
+Ascending;Aufsteigend
+Descending;Absteigend
 Rule;Regel
 Scrape Artwork;Scrape Bilddateien
 Scrape Fanart;Fanart extrahieren
@@ -476,7 +478,7 @@ _help_filter_delete;Lösche diesen Filter
 _help_filter_exception;Konfiguriere eine Filterausnahme. Stimmt ein Spiel mit dieser Ausnahme überein, wird es im Filter aufgelistet. Regeln und Ausnahmen werden in der selben Reihenfolge angewandt in der sie aufgelistet sind
 _help_filter_list_limit;Setze dies zu einem Wert ungleich Null um die Größe der sortierten Liste zu limitieren. Verwende einen positiven Wert für die ersten X Einträge (z.B. "10" für die ersten 10 Einträge), einen negativen Wert für die letzten X Einträge (z.B. "-25" für die letzten 25 Einträge), oder "0" für alle
 _help_filter_name;Bezeichnung für diesen Filter
-_help_filter_reverse_order;Kehrt die Sortierreihenfolge der Sammlung/ROM-Liste um. Standardmäßig wird die Liste alphabetisch (A bis Z) für Informationen, alphabetisch (Größte zuerst) für Statistiken oder gemäß der Quellliste (bei „Keine Sortierung“) sortiert.
+_help_filter_sort_order;Die Sortierreihenfolge der Sammlung/ROM-Liste. Aufsteigend ist „A bis Z“ für Informationen, „Kleinste bis Größte“ für Statistiken und die Quellenreihenfolge für „Keine Sortierung“. Absteigend ist die umgekehrte Reihenfolge.
 _help_filter_rule;Konfiguriere Filterregel
 _help_filter_sort_by;Das Spiel-Informationsattribut nach dem du die Sammlung/Romliste sortieren möchtest. Stelle auf "Keine Sortierung" um die Sortierung der Quell-Sammlung/Romliste zu verwenden
 _help_game_custom_args;Nutze dies, um die Standard Kommandozeilenattribute für dieses Spiel außer Kraft zu setzen. Setze das Argument [nothing] wenn hierbei keine Parameter angewandt werden sollen. Folgendes kann analog verwendet werden: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn]

--- a/resources/language/en.msg
+++ b/resources/language/en.msg
@@ -100,7 +100,9 @@ Overview;Overview
 Plugins;Plugins
 Power Saving;Power Saving
 Remove Input;Remove Input
-Reverse Order;Reverse Order
+Sort Order;Sort Order
+Ascending;Ascending
+Descending;Descending
 Rule;Rule
 Scrape Artwork;Scrape Artwork
 Scrape Fanart;Scrape Fanart
@@ -476,7 +478,7 @@ _help_filter_delete;Delete this filter
 _help_filter_exception;Configure this filter exception.  If a game matches an exception it will be listed in the filter.  Rules and exceptions get applied in the order that they are listed
 _help_filter_list_limit;Set this to a non-zero value if you wish to limit the size of a sorted list.  Use a positive value for the first X entries (i.e. "10" gives the first 10 entries), a negative value for the last X entries (i.e. "-25" gives the last 25 entries), or "0" for no limit
 _help_filter_name;The name for this filter
-_help_filter_reverse_order;Reverse the order of the sorted collection/romlist.  Default order is "A to Z" for info, "Largest to Smallest" for stats, or the source list order for "No Sort"
+_help_filter_sort_order;The sorting order of the collection/romlist.  Ascending is "A to Z" for info, "Smallest to Largest" for stats, and the source order for "No Sort".  Descending is the reverse of those orders.
 _help_filter_rule;Configure this filter rule.  A game must match all filter rules (or a single exception) to be listed in a filter
 _help_filter_sort_by;The game information attribute that you wish to sort the collection/romlist by.  Set to "No Sort" to keep the ordering from the source collection/romlist
 _help_game_custom_args;Set this to override the default command line arguments for this game.  Set this to [nothing] if you want to override with no parameters.  The following get substituted appropriately: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn]

--- a/resources/language/es.msg
+++ b/resources/language/es.msg
@@ -100,7 +100,9 @@ Overview;Resumen
 Plugins;Complementos
 Power Saving;Ahorro de energía
 Remove Input;Eliminar control
-Reverse Order;Orden inverso
+Sort Order;Orden de clasificación
+Ascending;Ascendente
+Descending;Descendente
 Rule;Regla
 Scrape Artwork;Escrapear Artes
 Scrape Fanart;Escrapear Fanart
@@ -476,7 +478,7 @@ _help_filter_delete;Borrar este filtro
 _help_filter_exception;Configura esta excepción de filtro. Si un juego coincide con una excepción, aparecerá en el filtro. Las reglas y excepciones se aplican en el orden en que aparecen.
 _help_filter_list_limit;Configurar esto a cero si desea limitar el tamaño de una lista ordenada. Use un valor positivo para las X primeras entradas (por ej. "10" entrega las primeras 10 entradas), un valor negativo para las últimas X entradas (por ej. "-25" entrega las últimas 25 entradas), o "0" para ilimitado
 _help_filter_name;Nombra este filtro
-_help_filter_reverse_order;Invierte el orden de la colección/lista de ROMs. El orden predeterminado es de la A a la Z para información, de mayor a menor para estadísticas o el orden de la lista de origen para "Sin ordenar".
+_help_filter_sort_order;El orden de clasificación de la colección/lista de ROMs. Ascendente: de la A a la Z para la información, de menor a mayor para las estadísticas y el orden de origen para "Sin clasificación". Descendente: el orden inverso.
 _help_filter_rule;Configura regla para el filtro
 _help_filter_sort_by;Atriburo del juego a partir del cual desea que la colección/lista de roms sea ordenada. Configure a "No ordenar" para mantener el orden de la colección/lista de ROMs
 _help_game_custom_args;Establece esto para anular los argumentos de línea de comandos predeterminados para este juego. Déjalo en blanco si quieres anularlos sin parámetros. Se sustituyen los siguientes elementos según corresponda: [nombre], [romext], [ruta_rom], [emulador], [nombre_archivo_rom], [sistema], [sisteman]

--- a/resources/language/fr.msg
+++ b/resources/language/fr.msg
@@ -100,7 +100,9 @@ Overview;Aperçu
 Plugins;Plugins
 Power Saving;Économie d'énergie
 Remove Input;Enlever le contrôle
-Reverse Order;Ordre inverse
+Sort Order;Ordre de tri
+Ascending;Ascendant
+Descending;Descendant
 Rule;Règle
 Scrape Artwork;Aspirer les Artworks
 Scrape Fanart;Aspire les 'Fanart'
@@ -476,7 +478,7 @@ _help_filter_delete;Supprimer ce filtre
 _help_filter_exception;Configurer cette exception de filtre. Si un jeu correspond à une exception, il sera ajouté au filtre. Les règles et exceptions sont appliquées dans l'ordre de leur apparition.
 _help_filter_list_limit;Saisir un nombre différent de zéro pour limiter la taille de la liste triée. Un nombre positif remonte les X premières valeurs (ex : "10" donne les 10 premières valeurs), un nombre négatif remonte les X dernières valeurs (ex : "-25" donne les 25 dernières valeurs). "0" affiche toute la liste.
 _help_filter_name;Nom du filtre
-_help_filter_reverse_order;Inverser l'ordre de tri de la collection/liste de ROM L'ordre par défaut est «A à Z» pour les informations, «Du plus grand au plus petit» pour les statistiques, ou l'ordre de la liste source pour «Aucun tri».
+_help_filter_sort_order;L'ordre de tri de la collection/romlist. Le tri croissant correspond à « A à Z » pour les informations, « Du plus petit au plus grand » pour les statistiques, et l'ordre source pour « Aucun tri ». Le tri décroissant correspond à l'ordre inverse.
 _help_filter_rule;Configurer le filtre
 _help_filter_sort_by;C'est l'information du jeu par lequel vous souhaitez classer votre liste. Sélectionner "Non classé" pour conserver l'ordre de la liste de rom source.
 _help_game_custom_args;Définir cette option pour remplacer les arguments de ligne de commande par défaut de ce jeu. Laisser vide si vous souhaitez les remplacer sans paramètres. Les éléments suivants sont remplacés correctement: [nom], [romext], [chemin_rom], [émulateur], [nom_fichier_rom], [système], [n_système]

--- a/resources/language/it.msg
+++ b/resources/language/it.msg
@@ -100,7 +100,9 @@ Overview;Panoramica
 Plugins;Plugin
 Power Saving;Risparmio energetico
 Remove Input;Eliminare il controllo
-Reverse Order;Ordine inverso
+Sort Order;Ordine di visualizzazione
+Ascending;In salita
+Descending;In discesa
 Rule;Regola
 Scrape Artwork;Recupera le immagini
 Scrape Fanart;Recupera le fanart
@@ -476,7 +478,7 @@ _help_filter_delete;Cancella questo filtro
 _help_filter_exception;Configura l'eccezione
 _help_filter_list_limit;Imposta un valore diverso da zero se vuoi limitare il numero di voci presenti nella lista. Utilizza un valore positivo per recuperare i primi titoli (per esempio "10" restituirà i primi 10 titoli), un valore negativo per recuperare gli ultimi (per esempio "-25" restituirà gli ultimi 25 titoli), oppure "0" per averli tutti
 _help_filter_name;Il nome di questo filtro
-_help_filter_reverse_order;Inverti l'ordine della raccolta/elenco rom ordinati. L'ordine predefinito è "dalla A alla Z" per le informazioni, "dal più grande al più piccolo" per le statistiche o l'ordine dell'elenco sorgente per "Nessun ordinamento".
+_help_filter_sort_order;L'ordine di visualizzazione della collezione/lista ROM. Crescente è "Dalla A alla Z" per le informazioni, "Dal più piccolo al più grande" per le statistiche e l'ordine di origine per "Nessun ordinamento". Decrescente è l'inverso di questi ordini.
 _help_filter_rule;Configura le regole per il filtro
 _help_filter_sort_by;L'attributo del gioco che deve essere utilizzato per ordinare la lista. Imposta "Nessun ordinamento" per mantenere l'ordinamento originale della lista
 _help_game_custom_args;Imposta dei parametri differenti per questo gioco

--- a/resources/language/jp.msg
+++ b/resources/language/jp.msg
@@ -100,7 +100,9 @@ Overview;概要
 Plugins;プラグイン
 Power Saving;省電力
 Remove Input;キー削除
-Reverse Order;逆順
+Sort Order;並べ替え順序
+Ascending;上昇
+Descending;下降
 Rule;ルール
 Scrape Artwork;ファンアートーワークをダウンロード
 Scrape Fanart;ファンアートをスクレイピング
@@ -476,7 +478,7 @@ _help_filter_delete;このフィルターを削除します
 _help_filter_exception;このフィルター例外を構成します。ゲームが例外に一致する場合、フィルターにリストされます。ルールと例外は、リストされている順序で適用されます。
 _help_filter_list_limit;リストのサイズに制限を付けます. プラスで上からの××個, マイナスで下からの××個を設定します. 0 は無限です.
 _help_filter_name;フィルターの名前
-_help_filter_reverse_order;ソートされたコレクション/ROMリストの順序を反転します。デフォルトの順序は、情報の場合は「AからZ」、統計情報の場合は「最大から最小」、または「ソートなし」の場合はソースリストの順序です。
+_help_filter_sort_order;コレクション／ROMリストの並べ替え順序。昇順は、情報表示では「AからZ」、統計情報表示では「小さい順から大きい順」、並べ替えなしの場合は元の順序となります。降順は、これらの順序の逆になります。
 _help_filter_rule;フィルターのルールを設定します
 _help_filter_sort_by;リストの並び方を設定します. "並び替えない" で元の順番で並べます.
 _help_game_custom_args;このゲームのデフォルトのコマンドライン引数をオーバーライドするには、これを設定します。パラメータなしでオーバーライドする場合は、[nothing] に設定します。以下の項目は適切に置換されます: [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn]

--- a/resources/language/kr.msg
+++ b/resources/language/kr.msg
@@ -100,7 +100,9 @@ Overview;설명
 Plugins;플러그인
 Power Saving;절전
 Remove Input;입력 삭제
-Reverse Order;역순
+Sort Order;정렬 순서
+Ascending;상승
+Descending;하강
 Rule;규칙
 Scrape Artwork;팬 아트워크 다운로드
 Scrape Fanart;외부 팬아트 다운로드
@@ -476,7 +478,7 @@ _help_filter_delete;본 필터를 삭제합니다.
 _help_filter_exception;이 필터의 예외 사항을 설정합니다. 게임이 이 규칙을 만족하면 필터에 추가됩니다. 규칙과 필터는 추가된 순서대로 적용됩니다
 _help_filter_list_limit;목록의 크기 제한을 설정할 수 있습니다. 양수는 상위 X 개, 음수는 하위 X 개를 지정하는 데 사용할 수 있습니다. 0 은 무제한입니다.
 _help_filter_name;필터의 이름
-_help_filter_reverse_order;정렬된 컬렉션/ROM 목록의 순서를 반대로 바꿉니다. 기본 순서는 정보의 경우 "A-Z", 통계의 경우 "내림차순", "정렬 안 함"의 경우 소스 목록 순서입니다.
+_help_filter_sort_order;컬렉션/롬리스트의 정렬 순서입니다. 오름차순은 정보의 경우 "A에서 Z" 순서, 통계의 경우 "작은 것에서 큰 것" 순서이며, "정렬 안 함"의 경우 출처 순서입니다. 내림차순은 이러한 순서의 반대입니다.
 _help_filter_rule;필터의 규칙을 정의합니다.
 _help_filter_sort_by;목록을 정렬할 기준을 설정합니다. 원래 목록 순서대로 표시하려면 '정렬 안 함' 을 선택하십시오.
 _help_game_custom_args;이 게임을 실행할 에뮬레이터의 기본 매개변수를 덮어씁니다. 빈 값으로 덮어쓰려면 [nothing]을 입력하여 주십시오. 사용 가능한 매크로는 다음과 같습니다. [name], [romext], [rompath], [emulator], [romfilename], [system], [systemn]

--- a/resources/language/tw.msg
+++ b/resources/language/tw.msg
@@ -100,7 +100,9 @@ Overview;簡介
 Plugins;插件
 Power Saving;省電模式
 Remove Input;移除輸入按鍵
-Reverse Order;反向排序
+Sort Order;排序方式
+Ascending;上升
+Descending;下降
 Rule;規則
 Scrape Artwork;搜刮插圖
 Scrape Fanart;搜刮玩家自製插圖
@@ -476,7 +478,7 @@ _help_filter_delete;刪除這個遊戲過濾
 _help_filter_exception;設定這個遊戲過濾的例外條件 (若遊戲符合這個例外條件,它將會列在這個遊戲過濾裡)
 _help_filter_list_limit;設為 0 為無限制,若你想限制排序清單的數量請設為 0 之外的數值 (例: "10" 將會取得前 10 個項目,"-25" 將會取得最後 25 個項目)
 _help_filter_name;這個遊戲過濾的名稱
-_help_filter_reverse_order;反轉已排序的收藏集/ROM清單的順序。預設順序為：資訊依「A到Z」排序,統計資料依「由大到小」排序,或依來源清單順序排序 (不排序)。
+_help_filter_sort_order;收藏/ROM清單的排序方式。升序排列,資訊依字母順序「A」到字母「Z」排列,統計資料依檔案大小「從小到大」排列,不排序則依檔案來源順序排列。降序排列與上述順序相反。
 _help_filter_rule;設定這個遊戲過濾的規則 (遊戲必須符合所有過濾規則或例外條件才會列在這個遊戲過濾)
 _help_filter_sort_by;設定用來排序收藏集/遊戲清單的遊戲資訊屬性 (設為「不排序」則保持收藏集/遊戲清單原始的排序順序)
 _help_game_custom_args;設定此項目將會替這個遊戲覆寫預設的命令參數,設為 [nothing] 則會覆寫為無參數 (可用的變數: [name]、[romext]、[rompath]、[emulator]、[romfilename]、[system]、[systemn])

--- a/src/fe_cache.cpp
+++ b/src/fe_cache.cpp
@@ -725,7 +725,7 @@ std::string FeCache::get_filter_id(
 	if ( !filter ) return id;
 
 	id += as_str( filter->get_sort_by() ) + ";";
-	id += as_str( filter->get_reverse_order() ) + ";";
+	id += as_str( filter->get_ascending_order() ) + ";";
 	id += as_str( filter->get_list_limit() ) + ";";
 
 	std::vector<FeRule> &rules = filter->get_rules();

--- a/src/fe_config.cpp
+++ b/src/fe_config.cpp
@@ -82,7 +82,7 @@ int FeMenuOpt::get_vindex() const
 // Return standardized "yes" or "no" string depending on list index
 const char* FeMenuOpt::get_bool()
 {
-	return ( m_list_index == 0 ) ? FE_CFG_YES_STR : FE_CFG_NO_STR;
+	return bool_to_config_str( m_list_index == 0 );
 }
 
 void FeMenuOpt::set_value( const std::string &s )
@@ -927,14 +927,15 @@ void FeFilterEditMenu::get_options( FeConfigContext &ctx )
 		if ( m_index >= 0 ) // don't add the following options for the global filter
 		{
             FeRomInfo::Index sort_by = f->get_sort_by();
-			bool reverse_order = f->get_reverse_order();
-			if ( FeRomInfo::isNumeric( sort_by ) ) reverse_order = !reverse_order;
-            std::vector<std::string> sort_opts = _( FeRomInfo::indexStrings );
+			std::vector<std::string> sort_opts = _( FeRomInfo::indexStrings );
 			sort_opts.push_back( _( "No Sort" ) );
 			std::string sort_str = value_at( sort_opts, sort_by );
 
+			std::vector<std::string> order_opts = {_( "Ascending" ), _( "Descending" )};
+			std::string order_str = f->get_ascending_order() ? order_opts[0] : order_opts[1];
+
 			ctx.add_opt( Opt::LIST, _( "Sort By" ), sort_str, _( "_help_filter_sort_by" ) )->append_vlist( sort_opts );
-			ctx.add_opt( Opt::TOGGLE, _( "Reverse Order" ), reverse_order, _( "_help_filter_reverse_order" ) );
+			ctx.add_opt( Opt::LIST, _( "Sort Order" ), order_str, _( "_help_filter_sort_order" ) )->append_vlist( order_opts );
 			ctx.add_opt( Opt::EDIT, _( "List Limit" ), as_str( f->get_list_limit() ), _( "_help_filter_list_limit" ) );
 			ctx.add_opt( Opt::EXIT, _( "Delete this Filter" ), "", _( "_help_filter_delete" ), 3);
 		}
@@ -1002,13 +1003,8 @@ bool FeFilterEditMenu::save( FeConfigContext &ctx )
 		FeRomInfo::Index sort_by = (FeRomInfo::Index)ctx.opt_list[ sort_pos ].get_vindex();
 		f->set_sort_by( sort_by );
 
-		// NOTE: reverse_order is *displayed* opposite for numerically sorted fields (stats)
-		// Users expect numeric fields to display descending by default
-		// - False (Default) = A-Z, Large-Small
-		// - True (Reversed) = Z-A, Small-Large
-		bool reverse_order = ctx.opt_list[ sort_pos + 1 ].get_vindex() == 0;
-		if ( FeRomInfo::isNumeric( sort_by ) ) reverse_order = !reverse_order;
-		f->set_reverse_order( reverse_order );
+		bool asc_order = ctx.opt_list[ sort_pos + 1 ].get_vindex() == 0;
+		f->set_ascending_order( asc_order );
 
 		std::string limit_str = ctx.opt_list[ sort_pos + 2 ].get_value();
 		int list_limit = as_int( limit_str );

--- a/src/fe_info.cpp
+++ b/src/fe_info.cpp
@@ -686,7 +686,8 @@ const char *FeFilter::indexStrings[] =
 	"rule",
 	"exception",
 	"sort_by",
-	"reverse_order",
+	"ascending_order",
+	"reverse_order", // Deprecated 3.2.3+
 	"list_limit",
 	NULL
 };
@@ -697,6 +698,8 @@ FeFilter::FeFilter( const std::string &name )
 	m_list_limit( 0 ),
 	m_size( 0 ),
 	m_sort_by( FeRomInfo::LAST_INDEX ),
+	m_asc_order( true ),
+	m_asc_order_exists( false ),
 	m_reverse_order( false )
 {
 }
@@ -706,6 +709,56 @@ void FeFilter::init()
 	for ( std::vector<FeRule>::iterator itr=m_rules.begin();
 			itr != m_rules.end(); ++itr )
 		(*itr).init();
+}
+
+FeRomInfo::Index FeFilter::get_sort_by() const
+{
+	return m_sort_by;
+}
+
+bool FeFilter::get_ascending_order() const
+{
+	return m_asc_order_exists
+		? m_asc_order
+		: ( FeRomInfo::isNumeric( m_sort_by ) ? m_reverse_order : !m_reverse_order );
+}
+
+//
+// Reverse is a special case - Deprecated 3.2.3+
+// - String A-Z is default, Z-A is reverse
+// - Numeric 9-0 is default, 0-9 is reverse (more likely to want higher total first)
+//
+bool FeFilter::get_reverse_order() const
+{
+	return !m_asc_order_exists
+		? m_reverse_order
+		: ( FeRomInfo::isNumeric( m_sort_by ) ? m_asc_order : !m_asc_order );
+}
+
+int FeFilter::get_list_limit() const
+{
+	return m_list_limit;
+}
+
+void FeFilter::set_sort_by( FeRomInfo::Index i )
+{
+	m_sort_by = i;
+}
+
+void FeFilter::set_ascending_order( bool a )
+{
+	m_asc_order = a;
+	m_asc_order_exists = true;
+}
+
+void FeFilter::set_reverse_order( bool r )
+{
+	m_reverse_order = r;
+}
+
+void FeFilter::set_list_limit( int p )
+{
+	m_list_limit = p;
 }
 
 bool FeFilter::apply_filter( const FeRomInfo &rom ) const
@@ -744,7 +797,11 @@ int FeFilter::process_setting( const std::string &setting,
 			}
 		}
 	}
-	else if ( setting.compare( indexStrings[ReverseOrder] ) == 0 ) // reverse_order
+	else if ( setting.compare( indexStrings[AscendingOrder] ) == 0 ) // asc_order
+	{
+		set_ascending_order( config_str_to_bool( value, true ) );
+	}
+	else if ( setting.compare( indexStrings[ReverseOrder] ) == 0 ) // Deprecated 3.2.3+
 	{
 		set_reverse_order( config_str_to_bool( value, true ) );
 	}
@@ -768,8 +825,7 @@ void FeFilter::save( nowide::ofstream &f, const char *filter_tag, const int inde
 	if ( m_sort_by != FeRomInfo::LAST_INDEX )
 		write_pair( f, indexStrings[SortBy], FeRomInfo::indexStrings[ m_sort_by ], indent + 1 );
 
-	if ( m_reverse_order != false )
-		write_pair( f, indexStrings[ReverseOrder], "yes", indent + 1 );
+	write_pair( f, indexStrings[AscendingOrder], bool_to_config_str( m_asc_order ), indent + 1 );
 
 	if ( m_list_limit != 0 )
 		write_pair( f, indexStrings[ListLimit], as_str( m_list_limit ), indent + 1 );
@@ -800,6 +856,8 @@ void FeFilter::clear()
 	m_list_limit=0;
 	m_size=0;
 	m_sort_by=FeRomInfo::LAST_INDEX;
+	m_asc_order=true;
+	m_asc_order_exists=false;
 	m_reverse_order=false;
 }
 
@@ -827,8 +885,8 @@ FeDisplayInfo::FeDisplayInfo( const std::string &n )
 	m_global_filter( "" )
 {
 	m_info[ Name ] = n;
-	m_info[ InCycle ] = "yes";
-	m_info[ InMenu ] = "yes";
+	m_info[ InCycle ] = FE_CFG_YES_STR;
+	m_info[ InMenu ] = FE_CFG_YES_STR;
 }
 
 const std::string &FeDisplayInfo::get_info( int i ) const
@@ -1575,7 +1633,7 @@ int FePlugInfo::process_setting( const std::string &setting,
 void FePlugInfo::save( nowide::ofstream &f ) const
 {
 	write_section( f, "plugin", m_name );
-	write_pair( f, indexStrings[0], m_enabled ? "yes" : "no", 1 );
+	write_pair( f, indexStrings[0], bool_to_config_str( m_enabled ), 1 );
 	FeScriptConfigurable::save( f, 1 );
 	f << std::endl;
 }

--- a/src/fe_info.hpp
+++ b/src/fe_info.hpp
@@ -304,7 +304,14 @@ private:
 class FeFilter : public FeBaseConfigurable
 {
 public:
-	enum Index { Rule=0, Exception, SortBy, ReverseOrder, ListLimit };
+	enum Index {
+		Rule=0,
+		Exception,
+		SortBy,
+		AscendingOrder,
+		ReverseOrder, // Deprecated 3.2.3+
+		ListLimit
+	};
 	static const char *indexStrings[];
 
 	FeFilter( const std::string &name );
@@ -329,13 +336,15 @@ public:
 	std::vector<FeRule> &get_rules() { return m_rules; };
 	int get_rule_count() const { return m_rules.size(); };
 
-	FeRomInfo::Index get_sort_by() const { return m_sort_by; }
-	bool get_reverse_order() const { return m_reverse_order; }
-	int get_list_limit() const { return m_list_limit; }
+	FeRomInfo::Index get_sort_by() const;
+	bool get_ascending_order() const;
+	bool get_reverse_order() const;
+	int get_list_limit() const;
 
-	void set_sort_by( FeRomInfo::Index i ) { m_sort_by=i; }
-	void set_reverse_order( bool r ) { m_reverse_order=r; }
-	void set_list_limit( int p ) { m_list_limit=p; }
+	void set_sort_by( FeRomInfo::Index i );
+	void set_ascending_order( bool a );
+	void set_reverse_order( bool r );
+	void set_list_limit( int p );
 
 	// Returns true if any of the targets are used by sort or filter rules
 	bool test_for_targets( std::set<FeRomInfo::Index> targets ) const;
@@ -351,7 +360,9 @@ private:
 		// x values, Negative value limits to the last abs(x) values.
 	int m_size;
 	FeRomInfo::Index m_sort_by;
-	bool m_reverse_order;
+	bool m_asc_order;
+	bool m_asc_order_exists;
+	bool m_reverse_order; // Deprecated 3.2.3+
 };
 
 class FeScriptConfigurable : public FeBaseConfigurable

--- a/src/fe_input.cpp
+++ b/src/fe_input.cpp
@@ -1810,7 +1810,7 @@ void FeSoundInfo::save( nowide::ofstream &f ) const
 	for ( int i=0; i<3; i++ )
 		write_pair( f, settingStrings[i], as_str( get_set_volume( (SoundType)i ) ), 1 );
 
-	write_pair( f, settingStrings[3], m_loudness ? FE_CFG_YES_STR : FE_CFG_NO_STR, 1 );
+	write_pair( f, settingStrings[3], bool_to_config_str( m_loudness ), 1 );
 
 	for ( it=m_sounds.begin(); it!=m_sounds.end(); ++it )
 		write_pair( f, FeInputMap::commandStrings[ (*it).first ], (*it).second, 1 );

--- a/src/fe_overlay.cpp
+++ b/src/fe_overlay.cpp
@@ -62,34 +62,16 @@ int get_char_idx( unsigned char c )
 	return 0;
 }
 
-// Returns > 0 if value is "truthy", will match value of corresponding falsy
-const int is_truthy( const std::string value )
-{
-	if ( icompare( value, _( "Yes" )) == 0 ) return 1;
-	if ( icompare( value, _( "On" )) == 0 ) return 2;
-	if ( icompare( value, _( "True" )) == 0 ) return 3;
-	return 0;
-}
-
-// Returns > 0 if value is "falsy", will match value of corresponding truthy
-const int is_falsy( const std::string value )
-{
-	if ( icompare( value, _( "No" )) == 0 ) return 1;
-	if ( icompare( value, _( "Off" )) == 0 ) return 2;
-	if ( icompare( value, _( "False" )) == 0 ) return 3;
-	return 0;
-}
-
 // Returns true if the given list has a matching pair of truthy/falsy options in any order
 const bool is_bool_list( const std::vector<std::string> &values )
 {
 	if ( values.size() != 2 ) return false;
-	int v0 = is_truthy( values[0] );
-	int v1 = is_falsy( values[1] );
+	int v0 = is_str_truthy( values[0] );
+	int v1 = is_str_falsy( values[1] );
 	if ( !v0 || !v1 )
 	{
-		v0 = is_falsy( values[0] );
-		v1 = is_truthy( values[1] );
+		v0 = is_str_falsy( values[0] );
+		v1 = is_str_truthy( values[1] );
 	}
 	return v0 && v1 && ( v0 == v1 );
 }
@@ -103,7 +85,7 @@ std::string get_pill_glyph( bool checked )
 void swap_bool_to_pill_glyphs( std::vector<std::string> &right_list, const std::vector<FeMenuOpt> &opt_list, int idx )
 {
 	if ( !is_bool_list( opt_list[idx].values_list )) return;
-	right_list[ idx ] = get_pill_glyph( is_truthy( right_list[ idx ] ) );
+	right_list[ idx ] = get_pill_glyph( is_str_truthy( right_list[ idx ] ) );
 }
 
 };
@@ -1779,7 +1761,7 @@ int FeOverlay::display_config_dialog(
 			int original_value = ctx.curr_opt().get_vindex();
 			int new_value = ( original_value == 0 ) ? 1 : 0;
 			ctx.curr_opt().set_value( new_value );
-			ctx.right_list[ ctx.curr_sel ] = get_pill_glyph( is_truthy( ctx.curr_opt().values_list[new_value] ) );
+			ctx.right_list[ ctx.curr_sel ] = get_pill_glyph( is_str_truthy( ctx.curr_opt().values_list[new_value] ) );
 
 			vdialog.setCustomText( ctx.curr_sel, ctx.right_list );
 			layout_focus( sdialog, vdialog, LayoutFocus::Edit );

--- a/src/fe_present.cpp
+++ b/src/fe_present.cpp
@@ -997,32 +997,22 @@ int FePresent::get_selection_index() const
 
 int FePresent::get_sort_by() const
 {
-	FeRomInfo::Index idx;
-	bool rev;
-	int limit;
-
-	m_feSettings->get_current_sort( idx, rev, limit );
-	return idx;
+	return m_feSettings->get_sort_by();
 }
 
 bool FePresent::get_reverse_order() const
 {
-	FeRomInfo::Index idx;
-	bool rev;
-	int limit;
+	return m_feSettings->get_reverse_order();
+}
 
-	m_feSettings->get_current_sort( idx, rev, limit );
-	return rev;
+bool FePresent::get_ascending_order() const
+{
+	return m_feSettings->get_ascending_order();
 }
 
 int FePresent::get_list_limit() const
 {
-	FeRomInfo::Index idx;
-	bool rev;
-	int limit;
-
-	m_feSettings->get_current_sort( idx, rev, limit );
-	return limit;
+	return m_feSettings->get_list_limit();
 }
 
 void FePresent::set_selection_index( int index )

--- a/src/fe_present.hpp
+++ b/src/fe_present.hpp
@@ -215,6 +215,7 @@ protected:
 	Sqrat::Array get_tags_available() const;
 	int get_selection_index() const;
 	int get_sort_by() const;
+	bool get_ascending_order() const;
 	bool get_reverse_order() const;
 	int get_list_limit() const;
 	void set_search_rule( const char * );

--- a/src/fe_romlist.cpp
+++ b/src/fe_romlist.cpp
@@ -538,7 +538,7 @@ void FeRomList::sort_filter_entry(
 
 	// Sort and limit the filtered list
 	FeRomInfo::Index sort_by = f->get_sort_by();
-	bool rev = f->get_reverse_order();
+	bool rev = !f->get_ascending_order();
 	int limit = f->get_list_limit();
 
 	// Sorting
@@ -552,7 +552,7 @@ void FeRomList::sort_filter_entry(
 		for ( itg = clone_group.begin(); itg != clone_group.end(); ++itg )
 			std::stable_sort( (*itg).second.begin(), (*itg).second.end(), FeRomListSorter2( sort_by, rev ) );
 	}
-	else if ( rev != false )
+	else if ( rev )
 	{
 		// If not sorted the romlist entry order is used - but may still be reversed
 		std::reverse( filter_list.begin(), filter_list.end() );

--- a/src/fe_settings.cpp
+++ b/src/fe_settings.cpp
@@ -2386,24 +2386,35 @@ const std::string &FeSettings::get_filter_name( int filter_index )
 	return f->get_name();
 }
 
-void FeSettings::get_current_sort( FeRomInfo::Index &idx, bool &rev, int &limit )
+FeFilter *FeSettings::get_current_filter()
 {
-	idx = FeRomInfo::LAST_INDEX;
-	rev = false;
-	limit = 0;
+	return ( m_current_display < 0 )
+		? NULL
+		: m_displays[m_current_display].get_filter( m_displays[m_current_display].get_current_filter_index() );
+}
 
-	if ( m_current_display < 0 )
-		return;
+FeRomInfo::Index FeSettings::get_sort_by()
+{
+	FeFilter *f = get_current_filter();
+	return f ? f->get_sort_by() : FeRomInfo::LAST_INDEX;
+}
 
-	FeFilter *f = m_displays[m_current_display].get_filter(
-			m_displays[m_current_display].get_current_filter_index() );
+bool FeSettings::get_ascending_order()
+{
+	FeFilter *f = get_current_filter();
+	return f ? f->get_ascending_order() : true;
+}
 
-	if ( f )
-	{
-		idx = f->get_sort_by();
-		rev = f->get_reverse_order();
-		limit = f->get_list_limit();
-	}
+bool FeSettings::get_reverse_order()
+{
+	FeFilter *f = get_current_filter();
+	return f ? f->get_reverse_order() : false;
+}
+
+int FeSettings::get_list_limit()
+{
+	FeFilter *f = get_current_filter();
+	return f ? f->get_list_limit() : 0;
 }
 
 void FeSettings::step_current_selection( int step )
@@ -3240,20 +3251,14 @@ bool FeSettings::get_special_token_value( std::string &token, int filter_index, 
 			return true;
 		case FeRomInfo::SortName:
 		{
-			FeRomInfo::Index sort_by;
-			bool reverse_sort;
-			int list_limit;
-			get_current_sort( sort_by, reverse_sort, list_limit );
+			FeRomInfo::Index sort_by = get_sort_by();
 			std::string sort_token = ( sort_by == FeRomInfo::LAST_INDEX ) ? "None" : FeRomInfo::indexStrings[sort_by];
 			value = _( sort_token );
 			return true;
 		}
 		case FeRomInfo::SortValue:
 		{
-			FeRomInfo::Index sort_by;
-			bool reverse_sort;
-			int list_limit;
-			get_current_sort( sort_by, reverse_sort, list_limit );
+			FeRomInfo::Index sort_by = get_sort_by();
 			std::string sort_token = FeRomInfo::indexStrings[ ( sort_by == FeRomInfo::LAST_INDEX ) ? FeRomInfo::Title : sort_by ];
 			return get_token_value( sort_token, filter_index, rom_index, value );
 		}
@@ -3529,7 +3534,7 @@ const std::string FeSettings::get_info( int index ) const
 #ifdef SFML_SYSTEM_WINDOWS
 	case HideConsole:
 #endif
-		return ( get_info_bool( index ) ? FE_CFG_YES_STR : FE_CFG_NO_STR );
+		return bool_to_config_str( get_info_bool( index ) );
 	case VideoDecoder:
 #ifdef NO_MOVIE
 		return "software";

--- a/src/fe_settings.hpp
+++ b/src/fe_settings.hpp
@@ -471,7 +471,11 @@ public:
 	bool get_token_value( std::string &token, int filter_index, int rom_index, std::string &value );
 	bool get_special_token_value( std::string &token, int filter_index, int rom_index, std::string &value );
 
-	void get_current_sort( FeRomInfo::Index &idx, bool &rev, int &limit );
+	FeFilter *get_current_filter();
+	FeRomInfo::Index get_sort_by();
+	bool get_ascending_order();
+	bool get_reverse_order();
+	int get_list_limit();
 
 	const std::string &get_current_display_title() const;
 	const std::string &get_rom_info( int filter_offset, int rom_offset, FeRomInfo::Index index );

--- a/src/fe_util.cpp
+++ b/src/fe_util.cpp
@@ -1282,13 +1282,32 @@ int year_as_int( const std::string &s )
 	return as_int( y );
 }
 
+const int is_str_truthy( const std::string value )
+{
+	if ( icompare( value, "Yes" ) == 0 || icompare( value, _( "Yes" )) == 0 ) return 1;
+	if ( icompare( value, "On" ) == 0 || icompare( value, _( "On" )) == 0 ) return 2;
+	if ( icompare( value, "True" ) == 0 || icompare( value, _( "True" )) == 0 ) return 3;
+	return 0;
+}
+
+const int is_str_falsy( const std::string value )
+{
+	if ( icompare( value, "No" ) == 0 || icompare( value, _( "No" )) == 0 ) return 1;
+	if ( icompare( value, "Off" ) == 0 || icompare( value, _( "Off" )) == 0 ) return 2;
+	if ( icompare( value, "False" ) == 0 || icompare( value, _( "False" )) == 0 ) return 3;
+	return 0;
+}
 
 bool config_str_to_bool( const std::string &s, bool permissive )
 {
-	return permissive
-		? !(( icompare( s, "no" ) == 0 ) || ( icompare( s, "false" ) == 0 ))
-		: (( icompare( s, "yes" ) == 0 ) || ( icompare( s, "true" ) == 0 ));
+	return permissive ? !is_str_falsy( s ) : is_str_truthy( s );
 }
+
+const char *bool_to_config_str( const bool &b )
+{
+	return b ? FE_CFG_YES_STR : FE_CFG_NO_STR;
+}
+
 
 const char *get_OS_string()
 {

--- a/src/fe_util.hpp
+++ b/src/fe_util.hpp
@@ -394,12 +394,27 @@ std::string utf32_to_utf8( const std::basic_string<std::uint32_t> & );
 //
 std::string clean_str( const std::string & );
 
+// Returns > 0 if value is "truthy" (Yes, On, True)
+// - Will match value of corresponding is_str_falsy
+// - Also checks translated value
+const int is_str_truthy( const std::string value );
+
+// Returns > 0 if value is "falsy" (No, Off, False)
+// - Will match value of corresponding is_str_truthy
+// - Also checks translated value
+const int is_str_falsy( const std::string value );
+
 //
 // Return bool representing given string
 // - "yes" or "true" = true, anything else = false
 // - If permissive "no" or "false" = false, anything else = true
 //
 bool config_str_to_bool( const std::string &s, bool permissive = false );
+
+//
+// Return FE_CFG_YES_STR or FE_CFG_NO_STR
+//
+const char *bool_to_config_str( const bool &b );
 
 //
 // Return the name of the operating system.

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1367,7 +1367,8 @@ bool FeVM::on_new_layout()
 		.Prop( _SC("index"), &FeFilter::get_rom_index )
 		.Prop( _SC("size"), &FeFilter::get_size )
 		.Prop( _SC("sort_by"), &FeFilter::get_sort_by )
-		.Prop( _SC("reverse_order"), &FeFilter::get_reverse_order )
+		.Prop( _SC("ascending_order"), &FeFilter::get_ascending_order )
+		.Prop( _SC("reverse_order"), &FeFilter::get_reverse_order ) // Deprecated 3.2.3+, use sort_asc
 		.Prop( _SC("list_limit"), &FeFilter::get_list_limit )
 	);
 
@@ -2162,7 +2163,8 @@ public:
 				.Prop( _SC("index"), &FeFilter::get_rom_index )
 				.Prop( _SC("size"), &FeFilter::get_size )
 				.Prop( _SC("sort_by"), &FeFilter::get_sort_by )
-				.Prop( _SC("reverse_order"), &FeFilter::get_reverse_order )
+				.Prop( _SC("ascending_order"), &FeFilter::get_ascending_order )
+				.Prop( _SC("reverse_order"), &FeFilter::get_reverse_order ) // Deprecated 3.2.3+, use sort_asc
 				.Prop( _SC("list_limit"), &FeFilter::get_list_limit )
 			);
 
@@ -3210,12 +3212,7 @@ const char *FeVM::cb_get_game_info( int index, int offset, int filter_offset )
 
 	case FeRomInfo::LAST_INDEX+3: // SortValue
 		{
-			FeRomInfo::Index sort_by;
-			bool reverse_sort;
-			int list_limit;
-
-			fev->m_feSettings->get_current_sort( sort_by, reverse_sort, list_limit );
-
+			FeRomInfo::Index sort_by = fev->m_feSettings->get_sort_by();
 			retval = fev->m_feSettings->get_rom_info( filter_offset, offset,
 				( sort_by == FeRomInfo::LAST_INDEX ) ? FeRomInfo::Title : sort_by );
 		}


### PR DESCRIPTION
- Add `ascending_order` filter property
- Deprecate `reverse_order`

The old property will be migrated to the new one the next time a display is modified.

Note this will remove `reverse_order` from the `displays.cfg`.

**_ALL `reverse_order` FIELDS FOR ALL DISPLAYS WILL BE MIGRATED TO `ascending_order`_**

Fixes #391