### PR TITLE
Add Unit Lexer

### DIFF
--- a/extlibs/PATCH.md
+++ b/extlibs/PATCH.md
@@ -1,0 +1,9 @@
+# Patches
+
+Modifications (marked with `AM`) have been made to:
+
+- Squirrel
+  - [sqstdio.cpp](.\squirrel\sqstdlib\sqstdio.cpp)
+  - [sqcompiler.cpp](.\squirrel\squirrel\sqcompiler.cpp)
+  - [sqlexer.cpp](.\squirrel\squirrel\sqlexer.cpp)
+  - [sqlexer.h](.\squirrel\squirrel\sqlexer.h)

--- a/extlibs/squirrel/squirrel/sqcompiler.cpp
+++ b/extlibs/squirrel/squirrel/sqcompiler.cpp
@@ -612,6 +612,15 @@ public:
 		SQInteger pos = Factor();
 		for(;;) {
 			switch(_token) {
+			case TK_IDENTIFIER: // AM+ start
+				if(_lex._unit) {
+					pos = Factor();
+					SQInteger unit = _fs->PopTarget();
+					SQInteger num = _fs->PopTarget();
+					_fs->AddInstruction(_OP_CALL, _fs->PushTarget(), unit, num - 1, 2);
+					break;
+				}
+				return; // AM+ end
 			case _SC('.'):
 				pos = -1;
 				Lex(); 

--- a/extlibs/squirrel/squirrel/sqlexer.cpp
+++ b/extlibs/squirrel/squirrel/sqlexer.cpp
@@ -71,6 +71,7 @@ void SQLexer::Init(SQSharedState *ss, SQLEXREADFUNC rg, SQUserPointer up,Compile
 	_lasttokenline = _currentline = 1;
 	_currentcolumn = 0;
 	_prevtoken = -1;
+	_unit = SQFalse; // AM+
 	_reached_eof = SQFalse;
 	Next();
 }
@@ -485,5 +486,6 @@ SQInteger SQLexer::ReadID()
 	if(res == TK_IDENTIFIER || res == TK_CONSTRUCTOR) {
 		_svalue = &_longstr[0];
 	}
+	_unit = (_curtoken == TK_FLOAT || _curtoken == TK_INTEGER ); // AM+
 	return res;
 }

--- a/extlibs/squirrel/squirrel/sqlexer.h
+++ b/extlibs/squirrel/squirrel/sqlexer.h
@@ -33,6 +33,7 @@ public:
 	SQInteger _lasttokenline;
 	SQInteger _currentcolumn;
 	const SQChar *_svalue;
+	SQBool _unit; // AM+
 	SQInteger _nvalue;
 	SQFloat _fvalue;
 	SQLEXREADFUNC _readf;


### PR DESCRIPTION
```squirrel
/** Unit method `npx` becomes `px(n)` */
px <- function(n) { return n * 10 }

class UserConfig { </ help=10px /> text = "string" }
local c = compilestring("return 20"+"px;")

fe.log(UserConfig.getattributes("text").help) // 100 (attr)
fe.log(c()) // 200 (compiled)
fe.log(30px) // 300 (int)
fe.log(0x28px) // 400 (hex)
fe.log(0.5px * 100) // 500 (float)
fe.log(0.6e+2px) // 600 (scientific)
fe.log(0106px) // 700 (octal)
fe.log("800px") // 800px (String unaffected)
fe.log(@"
""
\""
900px
") // Multiline string unaffected
```