### PR TITLE
Fix constructor pixel_snap for all drawables

### DIFF
--- a/src/fe_image.cpp
+++ b/src/fe_image.cpp
@@ -1417,6 +1417,12 @@ FeImage::FeImage( FeImage *o, FePresentableParent &p ):
 
 FeImage::~FeImage() {}
 
+void FeImage::refresh_script_geometry()
+{
+	FeBasePresentable::refresh_script_geometry();
+	scale();
+}
+
 const FeBaseTextureContainer *FeImage::get_texture_container() const
 {
 	return m_tex;

--- a/src/fe_image.hpp
+++ b/src/fe_image.hpp
@@ -347,6 +347,7 @@ public:
 	void transition_swap( FeImage * );
 	bool fix_masked_image();
 	FePresentableParent *get_presentable_parent();
+	void refresh_script_geometry() override;
 	template <typename T>
 	void setSize( T w, T h ) { setSize( Vec2f( static_cast<float>( w ), static_cast<float>( h ) ) ); };
 	void setSize( const Vec2f &s );

--- a/src/fe_listbox.cpp
+++ b/src/fe_listbox.cpp
@@ -32,7 +32,7 @@
 
 const std::string DEFAULT_FORMAT_STRING = "[Title]";
 
-FeListBox::FeListBox( FePresentableParent &p, int x, int y, int w, int h )
+FeListBox::FeListBox( FePresentableParent &p, float x, float y, float w, float h )
 	: FeBasePresentable( p ),
 	m_selColour( Color::Yellow ),
 	m_selBg( Color::Blue ),

--- a/src/fe_listbox.hpp
+++ b/src/fe_listbox.hpp
@@ -49,7 +49,7 @@ public:
 		Bounded=3
 	};
 	// Constructor for use in scripts.  sets m_scripted to true
-	FeListBox( FePresentableParent &p, int x, int y, int w, int h );
+	FeListBox( FePresentableParent &p, float x, float y, float w, float h );
 
 	// Constructor for use in overlay.  sets m_scripted to false
 	FeListBox( FePresentableParent &p,

--- a/src/fe_present.cpp
+++ b/src/fe_present.cpp
@@ -1630,7 +1630,7 @@ FeModel3D *FePresent::add_clone( FeModel3D *o, FePresentableParent &p )
 	return new_model_3d;
 }
 
-FeText *FePresent::add_text( const std::string &n, int x, int y, int w, int h,
+FeText *FePresent::add_text( const std::string &n, float x, float y, float w, float h,
 			FePresentableParent &p )
 {
 	FeText *new_text = new FeText( p, n, x, y, w, h );
@@ -1649,7 +1649,7 @@ FeText *FePresent::add_text( const std::string &n, int x, int y, int w, int h,
 	return new_text;
 }
 
-FeListBox *FePresent::add_listbox( int x, int y, int w, int h,
+FeListBox *FePresent::add_listbox( float x, float y, float w, float h,
 		FePresentableParent &p )
 {
 	FeListBox *new_lb = new FeListBox( p, x, y, w, h );

--- a/src/fe_present.hpp
+++ b/src/fe_present.hpp
@@ -212,8 +212,8 @@ protected:
 	FeModel3D *add_model_3d(const std::string &n, FePresentableParent &p);
 	FeImage *add_clone(FeImage *, FePresentableParent &p);
 	FeModel3D *add_clone(FeModel3D *, FePresentableParent &p);
-	FeText *add_text(const std::string &n, int x, int y, int w, int h, FePresentableParent &p);
-	FeListBox *add_listbox(int x, int y, int w, int h, FePresentableParent &p);
+	FeText *add_text(const std::string &n, float x, float y, float w, float h, FePresentableParent &p);
+	FeListBox *add_listbox(float x, float y, float w, float h, FePresentableParent &p);
 	FeRectangle *add_rectangle(float x, float y, float w, float h, FePresentableParent &p);
 	FeImage *add_surface(float x, float y, float w, float h, int texture_width, int texture_height, FePresentableParent &p);
 	FeSound *add_sound(const char *n);

--- a/src/fe_presentable.cpp
+++ b/src/fe_presentable.cpp
@@ -651,7 +651,7 @@ FeModel3D *FePresentableParent::add_clone( FeModel3D *m )
 	return NULL;
 }
 
-FeText *FePresentableParent::add_text(const char *t, int x, int y, int w, int h)
+FeText *FePresentableParent::add_text(const char *t, float x, float y, float w, float h)
 {
 	FePresent *fep = FePresent::script_get_fep();
 
@@ -661,7 +661,7 @@ FeText *FePresentableParent::add_text(const char *t, int x, int y, int w, int h)
 	return NULL;
 }
 
-FeListBox *FePresentableParent::add_listbox(int x, int y, int w, int h)
+FeListBox *FePresentableParent::add_listbox(float x, float y, float w, float h)
 {
 	FePresent *fep = FePresent::script_get_fep();
 

--- a/src/fe_presentable.hpp
+++ b/src/fe_presentable.hpp
@@ -197,8 +197,8 @@ public:
 	FeModel3D *add_model_3d(const char *);
 	FeImage *add_clone(FeImage *);
 	FeModel3D *add_clone(FeModel3D *);
-	FeText *add_text(const char *,int, int, int, int);
-	FeListBox *add_listbox(int, int, int, int);
+	FeText *add_text(const char *,float, float, float, float);
+	FeListBox *add_listbox(float, float, float, float);
 	FeRectangle *add_rectangle(float, float, float, float);
 	FeImage *add_surface(float, float, float, float);
 	FeImage *add_surface(float, float, float, float, int, int);

--- a/src/fe_rectangle.cpp
+++ b/src/fe_rectangle.cpp
@@ -425,6 +425,7 @@ void FeRectangle::refresh_script_geometry()
 {
 	FeBasePresentable::refresh_script_geometry();
 	m_outline_thickness = m_outline;
+	scale();
 }
 
 float FeRectangle::get_corner_radius() const

--- a/src/fe_text.cpp
+++ b/src/fe_text.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 
 FeText::FeText( FePresentableParent &p, const std::string &str,
-	int x, int y, int w, int h )
+	float x, float y, float w, float h )
 	: FeBasePresentable( p ),
 	m_string( str ),
 	m_string_wrapped( str ),

--- a/src/fe_text.hpp
+++ b/src/fe_text.hpp
@@ -38,7 +38,7 @@ class FeText : public FeBasePresentable
 {
 public:
 	FeText( FePresentableParent &p,
-		const std::string &str, int x, int y, int w, int h );
+		const std::string &str, float x, float y, float w, float h );
 
 	void setFont( const FeFont & );
 	Vec2f getPosition() const;

--- a/src/fe_vm.cpp
+++ b/src/fe_vm.cpp
@@ -1665,8 +1665,8 @@ bool FeVM::on_new_layout()
 
 	fe.Func( _SC("add_clone"), &FeVM::cb_add_clone_presentable );
 
-	fe.Overload<FeText* (*)(const char *, int, int, int, int)>(_SC("add_text"), &FeVM::cb_add_text);
-	fe.Func<FeListBox* (*)(int, int, int, int)>(_SC("add_listbox"), &FeVM::cb_add_listbox);
+	fe.Overload<FeText* (*)(const char *, float, float, float, float)>(_SC("add_text"), &FeVM::cb_add_text);
+	fe.Func<FeListBox* (*)(float, float, float, float)>(_SC("add_listbox"), &FeVM::cb_add_listbox);
 	fe.Func<FeRectangle* (*)(float, float, float, float)>(_SC("add_rectangle"), &FeVM::cb_add_rectangle);
 	fe.Overload<FeImage* (*)(float, float, float, float, int, int)>(_SC("add_surface"), &FeVM::cb_add_surface);
 	fe.Overload<FeImage* (*)(float, float, float, float)>(_SC("add_surface"), &FeVM::cb_add_surface);
@@ -2935,7 +2935,7 @@ Sqrat::Object FeVM::cb_add_clone_presentable( FeBasePresentable *o )
 	return ret_obj;
 }
 
-FeText* FeVM::cb_add_text(const char *n, int x, int y, int w, int h )
+FeText* FeVM::cb_add_text(const char *n, float x, float y, float w, float h )
 {
 	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
 	FeVM *fev = (FeVM *)sq_getforeignptr( vm );
@@ -2951,7 +2951,7 @@ FeText* FeVM::cb_add_text(const char *n, int x, int y, int w, int h )
 	return ret;
 }
 
-FeListBox* FeVM::cb_add_listbox(int x, int y, int w, int h )
+FeListBox* FeVM::cb_add_listbox(float x, float y, float w, float h )
 {
 	HSQUIRRELVM vm = Sqrat::DefaultVM::Get();
 	FeVM *fev = (FeVM *)sq_getforeignptr( vm );

--- a/src/fe_vm.hpp
+++ b/src/fe_vm.hpp
@@ -203,8 +203,8 @@ public:
 	static FeImage *cb_add_artwork(const char *);
 	static FeModel3D *cb_add_model_3d(const char *);
 	static Sqrat::Object cb_add_clone_presentable( FeBasePresentable * );
-	static FeText *cb_add_text(const char *,int, int, int, int);
-	static FeListBox *cb_add_listbox(int, int, int, int);
+	static FeText *cb_add_text(const char *,float, float, float, float);
+	static FeListBox *cb_add_listbox(float, float, float, float);
 	static FeRectangle *cb_add_rectangle(float, float, float, float);
 	static FeImage *cb_add_surface(float, float, float, float);
 	static FeImage *cb_add_surface(float, float, float, float, int, int);


### PR DESCRIPTION
Replaced `int` to `float` in all drawable constructors
`fe.layout.pixel_snap` was not applied on `fe.add_*()`
